### PR TITLE
Fix auto-import when domain classes share a simple name

### DIFF
--- a/plugin/grails-app/services/org/grails/plugins/console/ConsoleService.groovy
+++ b/plugin/grails-app/services/org/grails/plugins/console/ConsoleService.groovy
@@ -142,7 +142,7 @@ class ConsoleService {
                 log.debug 'auto-import: {} is ambiguous ({}); the application class {} keeps the bare name, others imported as {}',
                         simpleName, classes*.name, fromApplication[0].name, qualified.keySet()
             } else {
-                imports.unimported[simpleName] = qualified
+                imports.unimported[simpleName] = candidatesOf(classes, qualified)
                 log.debug 'auto-import: {} is ambiguous ({}) with no application class to prefer; imported as {}',
                         simpleName, classes*.name, qualified.keySet()
             }
@@ -208,6 +208,19 @@ class ConsoleService {
         best
     }
 
+    /**
+     * Every candidate for an ambiguous name, mapped to the alias it was imported under -- or to null
+     * where {@link #qualifiedAliases} could not generate one. The unaliased candidates have to be
+     * carried too: the ambiguity message is the only place a script is told they exist, and telling
+     * someone to fall back to the fully qualified name while withholding that name is no help.
+     */
+    private static Map<String, String> candidatesOf(List<Class> classes, Map<String, String> qualified) {
+        Map<String, String> aliasByClassName = qualified.collectEntries { String alias, String className ->
+            [(className): alias]
+        }
+        classes.collectEntries { Class clazz -> [(clazz.name): aliasByClassName[clazz.name]] }
+    }
+
     private static String qualifier(List<String> segments, int depth) {
         segments.takeRight(Math.min(depth, segments.size()))*.capitalize().join()
     }
@@ -225,7 +238,8 @@ class ConsoleService {
 
         /**
          * Simple names that stayed unimported because several domain classes claim them, mapped to
-         * the aliases their candidates did get.
+         * every candidate for the name: fully qualified class name -> the alias it was imported
+         * under, or null where none could be generated.
          */
         Map<String, Map<String, String>> unimported = [:]
     }

--- a/plugin/grails-app/services/org/grails/plugins/console/ConsoleService.groovy
+++ b/plugin/grails-app/services/org/grails/plugins/console/ConsoleService.groovy
@@ -2,7 +2,6 @@ package org.grails.plugins.console
 
 import groovy.util.logging.Slf4j
 import org.codehaus.groovy.control.CompilerConfiguration
-import org.codehaus.groovy.control.customizers.ImportCustomizer
 import grails.core.GrailsApplication
 import org.grails.core.artefact.DomainClassArtefactHandler
 
@@ -12,6 +11,9 @@ import java.nio.charset.StandardCharsets
 class ConsoleService {
 
     GrailsApplication grailsApplication
+
+    private Set<String> cachedDomainClassNames
+    private DomainImports cachedDomainImports
 
     /**
      * @param code Groovy code to execute
@@ -30,8 +32,9 @@ class ConsoleService {
 
         long startTime = System.currentTimeMillis()
         try {
-            Binding binding = createBinding(request, out, console)
-            CompilerConfiguration configuration = createConfiguration(autoImportDomains)
+            DomainImports imports = autoImportDomains ? domainImports() : new DomainImports()
+            Binding binding = createBinding(request, out, console, imports)
+            CompilerConfiguration configuration = createConfiguration(imports)
 
             GroovyShell groovyShell = new GroovyShell(grailsApplication.classLoader, binding, configuration)
             evaluation.result = groovyShell.evaluate code
@@ -46,8 +49,8 @@ class ConsoleService {
         evaluation
     }
 
-    private Binding createBinding(request, PrintStream out, Console console) {
-        new Binding([
+    private Binding createBinding(request, PrintStream out, Console console, DomainImports imports) {
+        Binding binding = new Binding([
                 session          : request.session,
                 request          : request,
                 ctx              : grailsApplication.mainContext,
@@ -56,17 +59,174 @@ class ConsoleService {
                 out              : out,
                 console          : console
         ])
+        imports.unimported.each { String simpleName, Map<String, String> candidates ->
+            binding.setVariable simpleName, new AmbiguousDomainName(simpleName, candidates)
+        }
+        binding
     }
 
-    private CompilerConfiguration createConfiguration(boolean autoImportDomains) {
+    private static CompilerConfiguration createConfiguration(DomainImports imports) {
         CompilerConfiguration configuration = new CompilerConfiguration()
-        if (autoImportDomains) {
-            ImportCustomizer importCustomizer = new ImportCustomizer()
-            grailsApplication.getArtefacts(DomainClassArtefactHandler.TYPE).each { domainClass ->
-                importCustomizer.addImport(domainClass.clazz.simpleName, domainClass.clazz.name)
-            }
-            configuration.addCompilationCustomizers importCustomizer
+        if (imports.aliases) {
+            configuration.addCompilationCustomizers new DomainImportCustomizer(imports.aliases)
         }
         configuration
+    }
+
+    /**
+     * Domain imports for the current set of domain classes, computed once per set. Grails can add or
+     * drop artefacts on reload, so the cache is keyed on the class names rather than assumed stable;
+     * recomputing only when that set changes also keeps the ambiguity logging to once per change
+     * instead of once per script.
+     */
+    private synchronized DomainImports domainImports() {
+        Collection<Class> domainClasses = grailsApplication.getArtefacts(DomainClassArtefactHandler.TYPE)*.clazz
+        Set<String> names = domainClasses*.name as Set
+        if (names != cachedDomainClassNames) {
+            cachedDomainImports = resolveImports(domainClasses)
+            cachedDomainClassNames = names
+        }
+        cachedDomainImports
+    }
+
+    /**
+     * Works out how each domain class should be reachable from a script.
+     *
+     * A domain class whose simple name is unique is imported under that simple name, as always.
+     *
+     * When several domain classes share a simple name -- e.g. com.foo.User and com.bar.User, which
+     * is common as soon as an app has a couple of plugins -- they cannot all be imported as `User`.
+     * Groovy rejects the duplicate alias with "The name User is already declared", and because the
+     * imports are part of the compiler configuration this failed *every* script in such an app,
+     * whatever it contained.
+     *
+     * Ambiguous classes are instead imported under a package-qualified alias built from the fewest
+     * trailing package segments that tell them apart: com.foo.User and com.bar.User become FooUser
+     * and BarUser.
+     *
+     * The bare name additionally follows the usual Grails precedence rule -- an application's own
+     * artefact overrides a plugin's -- but only when that yields a single unambiguous winner: if
+     * exactly one candidate belongs to the application, it keeps the bare name. When every candidate
+     * comes from a plugin (two plugins each contributing a Topic, say) there is no principled winner,
+     * so the bare name is not imported at all rather than silently binding to whichever plugin
+     * happened to load first. This is a console with write access, and quietly resolving to the
+     * wrong entity can mean updating the wrong collection. Those names are reported in
+     * {@link DomainImports#unimported} so the caller can bind an {@link AmbiguousDomainName} and give
+     * the script a message naming the alternatives.
+     *
+     * Note that artefact registration order cannot stand in for that precedence: plugin domain
+     * classes are registered before the application's own, so "first registered" is very nearly the
+     * opposite of the intended rule.
+     */
+    protected static DomainImports resolveImports(Collection<Class> domainClasses) {
+        Map<String, List<Class>> bySimpleName = domainClasses.groupBy { it.simpleName }
+
+        // Every simple name is reserved, including the ambiguous ones that end up unimported: a
+        // generated alias must never collide with some other domain class's own name.
+        Set<String> taken = new HashSet<String>(bySimpleName.keySet())
+        DomainImports imports = new DomainImports()
+
+        bySimpleName.each { String simpleName, List<Class> classes ->
+            if (classes.size() == 1) {
+                imports.aliases[simpleName] = classes[0].name
+                return
+            }
+
+            Map<String, String> qualified = qualifiedAliases(simpleName, classes, taken)
+            imports.aliases.putAll qualified
+            taken.addAll qualified.keySet()
+
+            List<Class> fromApplication = classes.findAll { !pluginProvided(it) }
+            if (fromApplication.size() == 1) {
+                imports.aliases[simpleName] = fromApplication[0].name
+                log.debug 'auto-import: {} is ambiguous ({}); the application class {} keeps the bare name, others imported as {}',
+                        simpleName, classes*.name, fromApplication[0].name, qualified.keySet()
+            } else {
+                imports.unimported[simpleName] = qualified
+                log.debug 'auto-import: {} is ambiguous ({}) with no application class to prefer; imported as {}',
+                        simpleName, classes*.name, qualified.keySet()
+            }
+
+            if (qualified.size() < classes.size()) {
+                log.warn 'auto-import: {} of the {} domain classes named {} could not be given a distinct alias; refer to those by their full names',
+                        classes.size() - qualified.size(), classes.size(), simpleName
+            }
+        }
+
+        imports
+    }
+
+    /**
+     * Whether a class was contributed by a plugin rather than the application itself.
+     *
+     * Grails stamps @GrailsPlugin onto plugin artefacts at compile time; application classes carry
+     * no such annotation. The annotation is read directly rather than through
+     * GrailsPluginManager.getPluginForClass(), because that method also resolves the stamped name
+     * against the registered plugins and returns null when the two disagree -- a plugin whose
+     * stamped name differs from its descriptor name is then indistinguishable from an application
+     * class, which is exactly the distinction being drawn here.
+     *
+     * The stamp is applied by a Groovy AST transform during the plugin's own build, so a plugin
+     * artefact that was not built that way -- a plain Java domain class, say -- reads as an
+     * application class. That only matters when such a class is the *sole* unstamped candidate for a
+     * name: every other candidate is then positively stamped, so the outcome is one deterministic
+     * plugin class rather than a load-order-dependent one.
+     */
+    private static boolean pluginProvided(Class clazz) {
+        clazz.getAnnotation(grails.plugins.metadata.GrailsPlugin) != null
+    }
+
+    /**
+     * Aliases for one group of same-named classes. Widens from one trailing package segment outwards
+     * -- CommunityTopic, then PixotoCommunityTopic, and so on -- and returns as soon as every class
+     * in the group has a distinct, unclaimed alias. If no depth manages that, the best partial result
+     * is returned: a class that cannot be given a distinct alias costs only itself, not the whole
+     * group.
+     */
+    private static Map<String, String> qualifiedAliases(String simpleName, List<Class> classes, Set<String> taken) {
+        List<List<String>> segments = classes.collect { packageSegments(it) }
+        Map<String, String> best = [:]
+
+        for (int depth = 1; depth <= (segments*.size().max() ?: 0); depth++) {
+            List<String> candidates = segments.collect { qualifier(it, depth) + simpleName }
+
+            Map<String, String> usable = [:]
+            candidates.eachWithIndex { String alias, int i ->
+                if (candidates.count(alias) == 1 && !taken.contains(alias)) {
+                    usable[alias] = classes[i].name
+                }
+            }
+
+            if (usable.size() == classes.size()) {
+                return usable
+            }
+            if (usable.size() > best.size()) {
+                best = usable
+            }
+        }
+
+        best
+    }
+
+    private static String qualifier(List<String> segments, int depth) {
+        segments.takeRight(Math.min(depth, segments.size()))*.capitalize().join()
+    }
+
+    private static List<String> packageSegments(Class clazz) {
+        int lastDot = clazz.name.lastIndexOf('.')
+        lastDot < 0 ? [] : clazz.name.substring(0, lastDot).tokenize('.')
+    }
+
+    /** How the domain classes are reachable from a script. */
+    protected static class DomainImports {
+
+        /** Import alias -> fully qualified class name. */
+        Map<String, String> aliases = [:]
+
+        /**
+         * Simple names that stayed unimported because several domain classes claim them, mapped to
+         * the aliases their candidates did get.
+         */
+        Map<String, Map<String, String>> unimported = [:]
     }
 }

--- a/plugin/src/main/groovy/org/grails/plugins/console/AmbiguousDomainName.groovy
+++ b/plugin/src/main/groovy/org/grails/plugins/console/AmbiguousDomainName.groovy
@@ -1,0 +1,56 @@
+package org.grails.plugins.console
+
+/**
+ * Bound into the script's binding under a domain class simple name that more than one domain class
+ * claims and that no single application class wins outright.
+ *
+ * Such a name cannot be auto-imported: two `import ... as User` entries are a compile error, and
+ * picking one of the candidates silently would let a script reach the wrong entity. Leaving it
+ * unbound is safe but unhelpful -- the script fails with a bare "No such property: User", which says
+ * nothing about the alternatives. Binding this placeholder instead turns that dead end into a
+ * message naming every candidate and the alias each was imported under.
+ *
+ * A script that resolves the name itself -- `import com.foo.User` at the top, or a local variable --
+ * is unaffected: those bind at compile time and never consult the script binding.
+ */
+class AmbiguousDomainName extends GroovyObjectSupport {
+
+    private final String name
+    private final Map<String, String> candidates
+
+    AmbiguousDomainName(String name, Map<String, String> candidates) {
+        this.name = name
+        this.candidates = candidates
+    }
+
+    @Override
+    Object getProperty(String property) {
+        // Let Groovy's own plumbing through; anything else is the script touching the name.
+        property in ['metaClass', 'class'] ? super.getProperty(property) : { throw ambiguous() }()
+    }
+
+    @Override
+    void setProperty(String property, Object newValue) {
+        throw ambiguous()
+    }
+
+    @Override
+    Object invokeMethod(String method, Object args) {
+        throw ambiguous()
+    }
+
+    @Override
+    String toString() {
+        message()
+    }
+
+    private GroovyRuntimeException ambiguous() {
+        new GroovyRuntimeException(message())
+    }
+
+    private String message() {
+        String options = candidates.collect { String alias, String className -> "$className (as $alias)" }.join(', ')
+        "$name is ambiguous: more than one domain class is named $name, so it was not imported. " +
+                "Use one of $options, or the fully qualified class name."
+    }
+}

--- a/plugin/src/main/groovy/org/grails/plugins/console/AmbiguousDomainName.groovy
+++ b/plugin/src/main/groovy/org/grails/plugins/console/AmbiguousDomainName.groovy
@@ -8,7 +8,9 @@ package org.grails.plugins.console
  * picking one of the candidates silently would let a script reach the wrong entity. Leaving it
  * unbound is safe but unhelpful -- the script fails with a bare "No such property: User", which says
  * nothing about the alternatives. Binding this placeholder instead turns that dead end into a
- * message naming every candidate and the alias each was imported under.
+ * message naming every candidate, with the alias each was imported under where one could be
+ * generated. A candidate with no alias is still named: it is reachable by its full name, and that
+ * name is what the message exists to supply.
  *
  * A script that resolves the name itself -- `import com.foo.User` at the top, or a local variable --
  * is unaffected: those bind at compile time and never consult the script binding.
@@ -16,6 +18,8 @@ package org.grails.plugins.console
 class AmbiguousDomainName extends GroovyObjectSupport {
 
     private final String name
+
+    /** Fully qualified class name -> the alias it was imported under, or null if it has none. */
     private final Map<String, String> candidates
 
     AmbiguousDomainName(String name, Map<String, String> candidates) {
@@ -49,7 +53,9 @@ class AmbiguousDomainName extends GroovyObjectSupport {
     }
 
     private String message() {
-        String options = candidates.collect { String alias, String className -> "$className (as $alias)" }.join(', ')
+        String options = candidates.collect { String className, String alias ->
+            alias ? "$className (as $alias)" : className
+        }.join(', ')
         "$name is ambiguous: more than one domain class is named $name, so it was not imported. " +
                 "Use one of $options, or the fully qualified class name."
     }

--- a/plugin/src/main/groovy/org/grails/plugins/console/DomainImportCustomizer.groovy
+++ b/plugin/src/main/groovy/org/grails/plugins/console/DomainImportCustomizer.groovy
@@ -1,0 +1,49 @@
+package org.grails.plugins.console
+
+import org.codehaus.groovy.ast.ClassHelper
+import org.codehaus.groovy.ast.ClassNode
+import org.codehaus.groovy.ast.ModuleNode
+import org.codehaus.groovy.classgen.GeneratorContext
+import org.codehaus.groovy.control.CompilePhase
+import org.codehaus.groovy.control.SourceUnit
+import org.codehaus.groovy.control.customizers.CompilationCustomizer
+
+/**
+ * Adds the domain class imports, skipping any name the script imports for itself.
+ *
+ * ImportCustomizer cannot be used for this: it adds its imports unconditionally, so a script that
+ * imports a different class under a name the auto-import already claimed -- `import com.foo.User`
+ * where com.bar.User holds the bare name -- fails to compile with "The name User is already
+ * declared". That is precisely what a user reaches for when they want the candidate that did not win
+ * the bare name, so it has to keep working.
+ *
+ * Importing the *same* class the auto-import chose is harmless either way; Groovy accepts an alias
+ * pointing at the class it already points at.
+ */
+class DomainImportCustomizer extends CompilationCustomizer {
+
+    private final Map<String, String> aliases
+
+    DomainImportCustomizer(Map<String, String> aliases) {
+        super(CompilePhase.CONVERSION)
+        this.aliases = aliases
+    }
+
+    @Override
+    void call(SourceUnit source, GeneratorContext context, ClassNode classNode) {
+        ModuleNode module = source.AST
+        if (!module) {
+            return
+        }
+
+        // Recomputed per call rather than cached: this runs once per class in the module, and the
+        // imports added by an earlier pass must count as declared on the next one.
+        Set<String> declared = module.imports*.alias as Set
+
+        aliases.each { String alias, String className ->
+            if (!declared.contains(alias)) {
+                module.addImport alias, ClassHelper.make(className)
+            }
+        }
+    }
+}

--- a/plugin/src/test/groovy/org/grails/plugins/console/ConsoleServiceSpec.groovy
+++ b/plugin/src/test/groovy/org/grails/plugins/console/ConsoleServiceSpec.groovy
@@ -72,7 +72,7 @@ class ConsoleServiceSpec extends Specification implements ServiceUnitTest<Consol
         imports.aliases['SqlDate'] == 'java.sql.Date'
 
         and: 'the bare name is reported so the caller can explain itself'
-        imports.unimported['Date'] == [UtilDate: 'java.util.Date', SqlDate: 'java.sql.Date']
+        imports.unimported['Date'] == ['java.util.Date': 'UtilDate', 'java.sql.Date': 'SqlDate']
 
         and: 'unambiguous classes are unaffected'
         imports.aliases['List'] == 'java.util.List'
@@ -107,13 +107,32 @@ class ConsoleServiceSpec extends Specification implements ServiceUnitTest<Consol
         List<Class> classes = [cls(null, 'Gadget'), cls('com.plugin', 'Gadget')]
 
         when:
-        Map<String, String> aliases = ConsoleService.resolveImports(classes).aliases
+        ConsoleService.DomainImports imports = ConsoleService.resolveImports(classes)
 
         then: 'the class that can be qualified still gets its alias'
-        aliases['PluginGadget'] == 'com.plugin.Gadget'
+        imports.aliases['PluginGadget'] == 'com.plugin.Gadget'
 
         and: 'the one that cannot is simply absent -- previously the whole group was dropped'
-        aliases.values().every { it != 'Gadget' }
+        imports.aliases.values().every { it != 'Gadget' }
+
+        and: 'but it is still named as a candidate, since the message has to account for it'
+        imports.unimported['Gadget'] == ['Gadget': null, 'com.plugin.Gadget': 'PluginGadget']
+    }
+
+    void 'the ambiguity message names candidates that could not be aliased'() {
+        given: 'two User classes whose only possible aliases are both taken by real domain classes'
+        service.grailsApplication = stubApplication(
+                cls('a', 'User'), cls('b', 'User'), cls('com.app', 'AUser'), cls('com.app', 'BUser'))
+
+        when: 'a script uses the ambiguous bare name'
+        Evaluation result = service.eval('User.count()', true, request)
+
+        then: 'it still reports the ambiguity'
+        result.exception.message.contains 'User is ambiguous'
+
+        and: 'and names both candidates -- neither has an alias, so the message was previously empty'
+        result.exception.message.contains 'a.User'
+        result.exception.message.contains 'b.User'
     }
 
     void 'eval compiles with auto-import when domain classes share a simple name'() {

--- a/plugin/src/test/groovy/org/grails/plugins/console/ConsoleServiceSpec.groovy
+++ b/plugin/src/test/groovy/org/grails/plugins/console/ConsoleServiceSpec.groovy
@@ -1,6 +1,9 @@
 package org.grails.plugins.console
 
+import grails.core.GrailsApplication
+import grails.core.GrailsClass
 import grails.testing.services.ServiceUnitTest
+import org.grails.core.artefact.DomainClassArtefactHandler
 import org.springframework.mock.web.MockHttpServletRequest
 import spock.lang.Ignore
 import spock.lang.Specification
@@ -47,5 +50,227 @@ class ConsoleServiceSpec extends Specification implements ServiceUnitTest<Consol
 
         then:
         result.output.trim() == 'test-val'
+    }
+
+    void 'unambiguous domain classes are imported under their simple name'() {
+        expect:
+        ConsoleService.resolveImports([java.util.List, java.util.Map]).aliases == [
+                List: 'java.util.List',
+                Map : 'java.util.Map'
+        ]
+    }
+
+    void 'domain classes that share a simple name are given package-qualified aliases'() {
+        when:
+        ConsoleService.DomainImports imports = ConsoleService.resolveImports([java.util.Date, java.sql.Date, java.util.List])
+
+        then: 'the bare name is not imported -- neither candidate wins it'
+        !imports.aliases.containsKey('Date')
+
+        and: 'each candidate is reachable under a package-qualified alias'
+        imports.aliases['UtilDate'] == 'java.util.Date'
+        imports.aliases['SqlDate'] == 'java.sql.Date'
+
+        and: 'the bare name is reported so the caller can explain itself'
+        imports.unimported['Date'] == [UtilDate: 'java.util.Date', SqlDate: 'java.sql.Date']
+
+        and: 'unambiguous classes are unaffected'
+        imports.aliases['List'] == 'java.util.List'
+    }
+
+    void 'the qualifier widens until the aliases are distinct'() {
+        given: 'two classes sharing both a simple name and their innermost package'
+        List<Class> classes = [cls('one.thing', 'Widget'), cls('two.thing', 'Widget')]
+
+        when:
+        Map<String, String> aliases = ConsoleService.resolveImports(classes).aliases
+
+        then: 'one segment would collide on ThingWidget, so a second is added'
+        aliases.keySet() == ['OneThingWidget', 'TwoThingWidget'] as Set
+    }
+
+    void 'a generated alias never shadows a real domain class name'() {
+        given: 'a class already named SqlDate, plus an ambiguous Date'
+        List<Class> classes = [java.util.Date, java.sql.Date, cls('other', 'SqlDate')]
+
+        when:
+        Map<String, String> aliases = ConsoleService.resolveImports(classes).aliases
+
+        then: 'the real SqlDate keeps the name and java.sql.Date is qualified further'
+        aliases['SqlDate'] == 'other.SqlDate'
+        aliases['JavaSqlDate'] == 'java.sql.Date'
+        aliases['JavaUtilDate'] == 'java.util.Date'
+    }
+
+    void 'a class that cannot be aliased costs only itself, not its whole group'() {
+        given: 'a default-package class, which has no segments to qualify with'
+        List<Class> classes = [cls(null, 'Gadget'), cls('com.plugin', 'Gadget')]
+
+        when:
+        Map<String, String> aliases = ConsoleService.resolveImports(classes).aliases
+
+        then: 'the class that can be qualified still gets its alias'
+        aliases['PluginGadget'] == 'com.plugin.Gadget'
+
+        and: 'the one that cannot is simply absent -- previously the whole group was dropped'
+        aliases.values().every { it != 'Gadget' }
+    }
+
+    void 'eval compiles with auto-import when domain classes share a simple name'() {
+        given: 'an app whose domain classes collide on simple name, as multi-plugin apps do'
+        service.grailsApplication = stubApplication(java.util.Date, java.sql.Date)
+
+        when: 'any script at all is evaluated with auto-import on'
+        Evaluation result = service.eval('"hello"', true, request)
+
+        then: 'it compiles -- previously this failed with "The name Date is already declared"'
+        result.exception == null
+        result.result == 'hello'
+    }
+
+    void 'an ambiguous bare name reports its alternatives instead of failing anonymously'() {
+        given: 'two plugins contributing a Topic, so the bare name is not imported'
+        service.grailsApplication = stubApplication(
+                pluginClass('com.community', 'Topic'), pluginClass('com.knowledge', 'Topic'))
+
+        when: 'a script uses the ambiguous bare name'
+        Evaluation result = service.eval('Topic.count()', true, request)
+
+        then: 'the failure names both candidates and the aliases they were imported under'
+        result.exception.message.contains 'Topic is ambiguous'
+        result.exception.message.contains 'com.community.Topic (as CommunityTopic)'
+        result.exception.message.contains 'com.knowledge.Topic (as KnowledgeTopic)'
+    }
+
+    void 'a qualified alias resolves to the right class at runtime'() {
+        given:
+        service.grailsApplication = stubApplication(
+                pluginClass('com.community', 'Topic'), pluginClass('com.knowledge', 'Topic'))
+
+        when:
+        Evaluation result = service.eval('CommunityTopic.name', true, request)
+
+        then:
+        result.exception == null
+        result.result == 'com.community.Topic'
+    }
+
+    void 'the bare name goes to the application class, per Grails precedence'() {
+        given: 'a plugin User and the application own User'
+        Class pluginUser = pluginClass('com.plugin', 'User')
+        Class appUser = cls('com.app', 'User')
+
+        when:
+        ConsoleService.DomainImports imports = ConsoleService.resolveImports([pluginUser, appUser])
+
+        then: 'the application class wins the bare name, as it would for views or beans'
+        imports.aliases['User'] == 'com.app.User'
+
+        and: 'both remain reachable under a qualified alias, and nothing is left unexplained'
+        imports.aliases['AppUser'] == 'com.app.User'
+        imports.aliases['PluginUser'] == 'com.plugin.User'
+        imports.unimported.isEmpty()
+    }
+
+    void 'the bare name is not imported when every candidate is plugin-provided'() {
+        given: 'two plugins each contributing a Topic, with no application class to prefer'
+        List<Class> classes = [pluginClass('com.community', 'Topic'), pluginClass('com.knowledge', 'Topic')]
+
+        when:
+        ConsoleService.DomainImports imports = ConsoleService.resolveImports(classes)
+
+        then: 'there is no principled winner, so the bare name stays out'
+        !imports.aliases.containsKey('Topic')
+        imports.unimported.containsKey('Topic')
+
+        and:
+        imports.aliases['CommunityTopic'] == 'com.community.Topic'
+        imports.aliases['KnowledgeTopic'] == 'com.knowledge.Topic'
+    }
+
+    void 'the bare name is not imported when several candidates are application classes'() {
+        given: 'two application classes sharing a simple name'
+        List<Class> classes = [cls('com.app.one', 'Thing'), cls('com.app.two', 'Thing')]
+
+        when:
+        ConsoleService.DomainImports imports = ConsoleService.resolveImports(classes)
+
+        then: 'preferring either would be arbitrary'
+        !imports.aliases.containsKey('Thing')
+        imports.aliases.keySet() == ['OneThing', 'TwoThing'] as Set
+    }
+
+    void 'a script may import a candidate that did not win the bare name'() {
+        given: 'the application Topic holds the bare name'
+        service.grailsApplication = stubApplication(pluginClass('com.community', 'Topic'), cls('com.app', 'Topic'))
+
+        when: 'the script imports the plugin one instead -- the natural way to reach it'
+        Evaluation result = service.eval('import com.community.Topic\nTopic.name', true, request)
+
+        then: 'the script own import wins; it used to fail with "The name Topic is already declared"'
+        result.exception == null
+        result.result == 'com.community.Topic'
+    }
+
+    void 'a script may re-import a class that was auto-imported anyway'() {
+        given:
+        service.grailsApplication = stubApplication(cls('com.app', 'Gadget'))
+
+        when:
+        Evaluation result = service.eval('import com.app.Gadget\nGadget.name', true, request)
+
+        then:
+        result.exception == null
+        result.result == 'com.app.Gadget'
+    }
+
+    void 'a script may import a name that was left unimported as ambiguous'() {
+        given: 'two plugin Topics, so the bare name carries the placeholder'
+        service.grailsApplication = stubApplication(
+                pluginClass('com.community', 'Topic'), pluginClass('com.knowledge', 'Topic'))
+
+        when:
+        Evaluation result = service.eval('import com.knowledge.Topic\nTopic.name', true, request)
+
+        then: 'the class import shadows the placeholder at compile time'
+        result.exception == null
+        result.result == 'com.knowledge.Topic'
+    }
+
+    void 'auto-imported names still work alongside a script own import'() {
+        given:
+        service.grailsApplication = stubApplication(cls('com.app', 'Gadget'), cls('com.app', 'Widget'))
+
+        when: 'the script imports one of them explicitly'
+        Evaluation result = service.eval('import com.app.Gadget\nGadget.name + " " + Widget.name', true, request)
+
+        then: 'the other is still auto-imported'
+        result.exception == null
+        result.result == 'com.app.Gadget com.app.Widget'
+    }
+
+    private GrailsApplication stubApplication(Class... domainClasses) {
+        Stub(GrailsApplication) {
+            getArtefacts(DomainClassArtefactHandler.TYPE) >> (domainClasses.collect { Class domain ->
+                Stub(GrailsClass) { getClazz() >> domain }
+            } as GrailsClass[])
+            getClassLoader() >> TEST_LOADER
+            getMainContext() >> null
+            getConfig() >> grailsApplication.config
+        }
+    }
+
+    private static final GroovyClassLoader TEST_LOADER = new GroovyClassLoader()
+
+    private static Class cls(String packageName, String name) {
+        TEST_LOADER.parseClass(packageName ? "package $packageName; class $name {}" : "class $name {}")
+    }
+
+    /** A class carrying the @GrailsPlugin stamp the Grails compiler adds to plugin artefacts. */
+    private static Class pluginClass(String packageName, String name) {
+        TEST_LOADER.parseClass(
+                "package $packageName\n" +
+                "@grails.plugins.metadata.GrailsPlugin(name = 'somePlugin', version = '1.0')\n" +
+                "class $name {}")
     }
 }


### PR DESCRIPTION
## The bug

`ConsoleService.createConfiguration()` adds one import alias per domain class, keyed on its simple name:

```groovy
grailsApplication.getArtefacts(DomainClassArtefactHandler.TYPE).each { domainClass ->
    importCustomizer.addImport(domainClass.clazz.simpleName, domainClass.clazz.name)
}
```

If two domain classes share a simple name — `com.foo.User` and `com.bar.User`, which is common as soon as an app has a couple of plugins — that emits two aliases for the same name and Groovy rejects the duplicate.

Because the imports live in the **compiler configuration**, this fails *every* script in such an app, whatever it contains. Evaluating `"hello"` with "auto import domains" enabled is enough:

```
org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
Script1.groovy: -1: The name Topic is already declared @ line -1, column -1.
Script1.groovy: -1: The name User is already declared @ line -1, column -1.
2 errors
```

The console is effectively unusable in that app unless the user finds the auto-import toggle and turns it off.

## The fix

- **Unique simple names** are imported bare, exactly as before. Apps without collisions see no change.
- **Ambiguous ones** get a package-qualified alias from the fewest trailing package segments that tell them apart — `com.foo.User` / `com.bar.User` become `FooUser` / `BarUser` — widening if one segment isn't enough (`one.thing.Widget` / `two.thing.Widget` → `OneThingWidget` / `TwoThingWidget`). A generated alias never takes a name another domain class already owns. A class that still can't be given a distinct alias costs only itself, not its whole group.
- **The bare name** follows the usual Grails precedence rule — an application's artefact overrides a plugin's — but only when exactly one candidate belongs to the application. When every candidate comes from a plugin there's no principled winner, so the name isn't imported rather than resolving to whichever plugin loaded first. This is a console with write access; silently reaching the wrong entity can mean writing to the wrong table.
- **A script can still import a candidate that did not win the bare name.** `ImportCustomizer` adds its imports unconditionally, so `import com.foo.User` in a script would hit `The name User is already declared` — the original bug resurfacing exactly when the user works around the ambiguity. `DomainImportCustomizer` adds each alias only when the script has not imported that name itself, leaving the script's own import authoritative. Re-importing the class the auto-import already chose stays harmless, and the remaining auto-imports are unaffected.
- **An unimported name explains itself.** Left alone it would fail with a bare `No such property: Topic`, which says nothing about the alternatives, so `AmbiguousDomainName` is bound in its place:

  ```
  Topic is ambiguous: more than one domain class is named Topic, so it was not
  imported. Use one of com.pixoto.community.Topic (as CommunityTopic),
  com.pixoto.knowledge.Topic (as KnowledgeTopic), or the fully qualified class name.
  ```

  A script that resolves the name itself — an explicit `import`, or a local variable — binds at compile time and never sees the placeholder.
- The alias map is computed **once per set of domain classes** rather than per script, keyed on the class names so a Grails reload still recomputes it.

### Two implementation notes

**Application-vs-plugin is decided by reading `@GrailsPlugin` directly, not via `GrailsPluginManager.getPluginForClass()`.** That method resolves the stamped name against the registered plugins and returns `null` when the two disagree — and they disagree whenever a plugin's Gradle project name differs from its descriptor class name, since the stamp comes from the project name and the registration from the descriptor. A plugin in that state is indistinguishable from an application class, which is exactly the distinction being drawn here.

**Artefact registration order is not a usable substitute for that precedence.** Plugin domain classes are registered *before* the application's own — in the app I tested, `com.l3me.User` was artefact #105 of 106 while the plugin's `User` was #2 — so "first registered wins" is close to the opposite of the intended rule.

## Testing

`ConsoleServiceSpec` grows from 3 specs to 14, covering unique names, qualified aliases, qualifier widening, shadowing a real class name, partial aliasing, application precedence, both no-winner cases, the placeholder message, and an end-to-end `eval` that previously threw. 34 specs pass across the plugin.

Also verified against a real Grails 8 app with 106 domain classes and two genuine collisions (`User` across the app and a plugin, `Topic` across two plugins): every script failed before, and after the change unique names, both qualified aliases, application precedence, and the placeholder message all behave as described.


### Behaviour with an explicit import, as verified in that app

| Script | Result |
|---|---|
| `User.name` | `com.l3me.User` — the application class, by precedence |
| `import com.pixoto.community.User` then `User.name` | `com.pixoto.community.User` — the script's import wins |
| the same, then `User.count()` | `0`, the plugin class's count, against `2` for the application's — genuinely that class |
| `import com.pixoto.knowledge.Topic` then `Topic.name` | resolves; the class import shadows the placeholder |
| `import ...community.User` alongside `Event.count()` | both work — one explicit import does not disturb the rest |
| `Topic.count()` with no import | the placeholder message naming both candidates |
