### PR TITLE
Serve jQuery UI and CodeMirror from webjars

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,19 +20,22 @@ A web-based Groovy console for interactive runtime application management and de
 
 ### Webjars (8.x)
 
-As of 8.x the plugin no longer bundles jQuery, Bootstrap or Bootstrap Icons in
-its own resources. It declares `org.webjars.npm:jquery`,
-`org.webjars.npm:bootstrap` and `org.webjars.npm:bootstrap-icons` as transitive
-runtime dependencies, served through Spring Boot's standard `/webjars/**`
-classpath mapping. Two things follow from this:
+As of 8.x the plugin no longer bundles its third-party libraries in its own
+resources. It declares `org.webjars.npm:jquery`, `org.webjars.npm:jquery-ui`,
+`org.webjars.npm:bootstrap`, `org.webjars.npm:bootstrap-icons` and
+`org.webjars.npm:codemirror` as transitive runtime dependencies, served through
+Spring Boot's standard `/webjars/**` classpath mapping. Two things follow from
+this:
 
 - If your security configuration restricts URLs, `/webjars/**` must remain
-  reachable. Bootstrap only affects styling, but the console does not work at
-  all without jQuery.
+  reachable. Bootstrap and the jQuery UI theme only affect styling, but the
+  console does not work at all without jQuery, jQuery UI or CodeMirror.
 - The console links whatever webjar version your application actually resolves
   (your dependency management — typically the `grails-bom` platform — wins over
   the plugin's requested version), so overriding any of these versions in your
   app is safe. jQuery has no version pinned here at all; the BOM supplies it.
+  The BOM does not manage jQuery UI or CodeMirror, so those carry versions from
+  the plugin's `gradle.properties`.
 
 #### Supplying your own copies
 
@@ -53,8 +56,10 @@ page. Drop the runtime dependencies too, so the jars stop shipping:
 ```groovy
 implementation('org.grails.plugins:grails-web-console:8.0.0') {
     exclude group: 'org.webjars.npm', module: 'jquery'
+    exclude group: 'org.webjars.npm', module: 'jquery-ui'
     exclude group: 'org.webjars.npm', module: 'bootstrap'
     exclude group: 'org.webjars.npm', module: 'bootstrap-icons'
+    exclude group: 'org.webjars.npm', module: 'codemirror'
 }
 ```
 
@@ -67,11 +72,22 @@ win the cascade and jQuery is defined before its bundle runs:
 <head>
   <asset:stylesheet href="webjars/bootstrap/%/dist/css/bootstrap.css"/>
   <asset:stylesheet href="webjars/bootstrap-icons/%/font/bootstrap-icons.css"/>
+  <asset:stylesheet href="webjars/jquery-ui/%/dist/themes/base/jquery-ui.css"/>
+  <asset:stylesheet href="webjars/codemirror/%/lib/codemirror.css"/>
+  <asset:stylesheet href="webjars/codemirror/%/theme/lesser-dark.css"/>
   <asset:javascript src="webjars/jquery/%/dist/jquery.js"/>
+  <asset:javascript src="webjars/jquery-ui/%/dist/jquery-ui.js"/>
   <asset:javascript src="webjars/bootstrap/%/dist/js/bootstrap.bundle.js"/>
+  <asset:javascript src="webjars/codemirror/%/lib/codemirror.js"/>
+  <asset:javascript src="webjars/codemirror/%/mode/groovy/groovy.js"/>
   <g:layoutHead/>
 </head>
 ```
+
+Order matters: jQuery UI extends jQuery, and the groovy mode registers itself
+against the CodeMirror core. Serving five libraries yourself is a fair amount of
+work — unless your application already ships all of them, leaving the flag at its
+default is usually the better trade.
 
 `%` (or `*`) stands in for the version, so the layout survives a Bootstrap
 upgrade — asset-pipeline matches it against the compiled manifest in production
@@ -79,9 +95,8 @@ and against its classpath resolvers in development. Keep exactly one version of
 each webjar on the classpath: the wildcard takes the first manifest key that
 matches, and iteration order is unspecified.
 
-The console needs jQuery, Bootstrap 5 CSS, the Bootstrap Icons font CSS and the
-Bootstrap JS bundle. Missing stylesheets leave it unstyled; missing jQuery
-leaves it blank.
+Missing stylesheets leave the console unstyled; missing jQuery, jQuery UI or
+CodeMirror leave it blank.
 
 ## Installation
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,7 @@ testLoggerVersion=4.0.0
 # Served as webjars at runtime; the gulp build reads these to generate the
 # /webjars/... links in the GSP fragments (single source of truth for both)
 bootstrapVersion=5.3.8
+jqueryUiVersion=1.14.2
 bootstrapIconsVersion=1.13.1
 
 org.gradle.caching=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,7 @@ testLoggerVersion=4.0.0
 # /webjars/... links in the GSP fragments (single source of truth for both)
 bootstrapVersion=5.3.8
 jqueryUiVersion=1.14.2
+codeMirrorVersion=5.65.21
 bootstrapIconsVersion=1.13.1
 
 org.gradle.caching=true

--- a/gulp-tasks/grails-builder.js
+++ b/gulp-tasks/grails-builder.js
@@ -33,12 +33,10 @@ export const build = async (isDebug, options) => {
     // every vendor library (see concatJsTask), so copying them in individually
     // would ship roughly a megabyte the page never requests. Debug links each
     // library separately and still needs them on disk. Stylesheets are linked
-    // individually in both modes, and the jQuery UI images are referenced
-    // relatively from its stylesheet, so both are always copied.
+    // individually in both modes, so they are always copied.
     const externalAssetStreams = [
         ...(options.paths.vendor.cssAssets || []),
         ...(isDebug ? options.paths.vendor.jsAssets || [] : []),
-        ...(options.paths.vendor.staticAssets || []),
     ].filter(asset => asset.src.startsWith('./node_modules/')).map(asset => {
         const destination = path.join(options.webDir, path.posix.dirname(asset.publicPath));
         return gulp.src(asset.src, { base: path.dirname(asset.src), encoding: false })
@@ -86,7 +84,7 @@ export const build = async (isDebug, options) => {
     // fragments rather than being folded into _css.gsp/_js.gsp: index.gsp
     // renders them ahead of those fragments (preserving cascade and load order)
     // and only when the consuming app has not set
-    // grails.plugin.console.bootstrap.enabled = false. They resolve against the
+    // grails.plugin.console.webjars.enabled = false. They resolve against the
     // app's /webjars/** classpath mapping at runtime. Written unconditionally,
     // empty if there are no tags, so the render never hits a missing template.
     const webjars = options.paths.vendor.webjars || { css: [], js: [] };

--- a/gulp-tasks/paths.js
+++ b/gulp-tasks/paths.js
@@ -15,6 +15,7 @@ const gradleProperties = Object.fromEntries(
 const bootstrapVersion = gradleProperties.bootstrapVersion;
 const bootstrapIconsVersion = gradleProperties.bootstrapIconsVersion;
 const jqueryUiVersion = gradleProperties.jqueryUiVersion;
+const codeMirrorVersion = gradleProperties.codeMirrorVersion;
 
 // Assets served from the consuming app's webjar classpath rather than copied
 // into the plugin's public resources. The generated GSP resolves the version
@@ -27,6 +28,8 @@ const webjars = {
         // the theme's images/ sit beside this file inside the jar, so its relative
         // url() references resolve without copying anything into the plugin
         { name: 'jquery-ui', file: 'dist/themes/base/jquery-ui.min.css', defaultVersion: jqueryUiVersion },
+        { name: 'codemirror', file: 'lib/codemirror.css', defaultVersion: codeMirrorVersion },
+        { name: 'codemirror', file: 'theme/lesser-dark.css', defaultVersion: codeMirrorVersion },
     ],
     js: [
         // jQuery first: the console's bundle expects it as a global. No
@@ -35,18 +38,13 @@ const webjars = {
         { name: 'jquery', file: 'dist/jquery.min.js' },
         { name: 'jquery-ui', file: 'dist/jquery-ui.min.js', defaultVersion: jqueryUiVersion },
         { name: 'bootstrap', file: 'dist/js/bootstrap.bundle.min.js', defaultVersion: bootstrapVersion },
+        // the groovy mode registers itself against the core, so it follows it
+        { name: 'codemirror', file: 'lib/codemirror.js', defaultVersion: codeMirrorVersion },
+        { name: 'codemirror', file: 'mode/groovy/groovy.js', defaultVersion: codeMirrorVersion },
     ],
 };
 
 const vendorCssAssets = [
-    {
-        src: './node_modules/codemirror/lib/codemirror.css',
-        publicPath: '/vendor/codemirror/lib/codemirror.css',
-    },
-    {
-        src: './node_modules/codemirror/theme/lesser-dark.css',
-        publicPath: '/vendor/codemirror/theme/lesser-dark.css',
-    },
     {
         src: './web/vendor/jquery-layout/css/jquery.layout.css',
         publicPath: '/vendor/jquery-layout/css/jquery.layout.css',
@@ -85,14 +83,6 @@ const vendorJsAssets = [
     {
         src: './web/vendor/js/plugins/jquery.hotkeys.js',
         publicPath: '/vendor/js/plugins/jquery.hotkeys.js',
-    },
-    {
-        src: './node_modules/codemirror/lib/codemirror.js',
-        publicPath: '/vendor/codemirror/lib/codemirror.js',
-    },
-    {
-        src: './node_modules/codemirror/mode/groovy/groovy.js',
-        publicPath: '/vendor/codemirror/mode/groovy/groovy.js',
     },
 ];
 

--- a/gulp-tasks/paths.js
+++ b/gulp-tasks/paths.js
@@ -14,6 +14,7 @@ const gradleProperties = Object.fromEntries(
 
 const bootstrapVersion = gradleProperties.bootstrapVersion;
 const bootstrapIconsVersion = gradleProperties.bootstrapIconsVersion;
+const jqueryUiVersion = gradleProperties.jqueryUiVersion;
 
 // Assets served from the consuming app's webjar classpath rather than copied
 // into the plugin's public resources. The generated GSP resolves the version
@@ -23,12 +24,16 @@ const webjars = {
     css: [
         { name: 'bootstrap', file: 'dist/css/bootstrap.min.css', defaultVersion: bootstrapVersion },
         { name: 'bootstrap-icons', file: 'font/bootstrap-icons.min.css', defaultVersion: bootstrapIconsVersion },
+        // the theme's images/ sit beside this file inside the jar, so its relative
+        // url() references resolve without copying anything into the plugin
+        { name: 'jquery-ui', file: 'dist/themes/base/jquery-ui.min.css', defaultVersion: jqueryUiVersion },
     ],
     js: [
         // jQuery first: the console's bundle expects it as a global. No
         // defaultVersion — the Grails BOM manages this one, so there is no
         // build-time version here to fall back to.
         { name: 'jquery', file: 'dist/jquery.min.js' },
+        { name: 'jquery-ui', file: 'dist/jquery-ui.min.js', defaultVersion: jqueryUiVersion },
         { name: 'bootstrap', file: 'dist/js/bootstrap.bundle.min.js', defaultVersion: bootstrapVersion },
     ],
 };
@@ -46,26 +51,9 @@ const vendorCssAssets = [
         src: './web/vendor/jquery-layout/css/jquery.layout.css',
         publicPath: '/vendor/jquery-layout/css/jquery.layout.css',
     },
-    {
-        src: './node_modules/jquery-ui/dist/themes/base/jquery-ui.min.css',
-        publicPath: '/vendor/jquery-ui/jquery-ui.min.css',
-    },
-];
-
-// Copied alongside the vendor css/js but never linked from the GSP fragments
-// (referenced relatively from the css they belong to)
-const vendorStaticAssets = [
-    {
-        src: './node_modules/jquery-ui/dist/themes/base/images/*',
-        publicPath: '/vendor/jquery-ui/images/*',
-    },
 ];
 
 const vendorJsAssets = [
-    {
-        src: './node_modules/jquery-ui/dist/jquery-ui.min.js',
-        publicPath: '/vendor/jquery-ui/jquery-ui.min.js',
-    },
     {
         src: './node_modules/underscore/underscore-min.js',
         publicPath: '/vendor/js/libs/underscore-min.js',
@@ -134,7 +122,6 @@ export const paths = {
         js: vendorJsAssets.map(asset => asset.publicPath),
         cssAssets: vendorCssAssets,
         jsAssets: vendorJsAssets,
-        staticAssets: vendorStaticAssets,
         webjars,
     },
     test: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "handlebars": "^4.7.9",
         "jasmine": "^5.13.0",
         "jquery": "^4.0.0",
-        "jquery-ui": "^1.14.2",
         "jsdom": "^29.1.1",
         "mkdirp": "^3.0.1",
         "through2": "^5.0.5",
@@ -2789,16 +2788,6 @@
       "integrity": "sha512-TXCHVR3Lb6TZdtw1l3RTLf8RBWVGexdxL6AC8/e0xZKEpBflBsjh9/8LXw+dkNFuOyW9B7iB3O1sP7hS0Kiacg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/jquery-ui": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/jquery-ui/-/jquery-ui-1.14.2.tgz",
-      "integrity": "sha512-1gSl7PUjyipa2adSr780Ujk16faicrV7PjPPzPtvWk7tTqBnsqp67NNV9jZK2+BIxUPXWSnIUU/LBCgwgGZE+Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "jquery": ">=1.12.0 <5.0.0"
-      }
     },
     "node_modules/js-yaml": {
       "version": "3.15.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "backbone": "^1.6.1",
         "backbone.marionette": "^3.5.1",
         "backbone.radio": "^2.0.0",
-        "codemirror": "^5.65.21",
         "del": "^8.0.1",
         "glob": "^13.0.6",
         "gulp": "^5.0.1",
@@ -1053,13 +1052,6 @@
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
-    },
-    "node_modules/codemirror": {
-      "version": "5.65.21",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.21.tgz",
-      "integrity": "sha512-6teYk0bA0nR3QP0ihGMoxuKzpl5W80FpnHpBJpgy66NK3cZv5b/d/HY8PnRvfSsCG1MTfr92u2WUl+wT0E40mQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/coffeescript": {
       "version": "2.7.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "backbone": "^1.6.1",
     "backbone.marionette": "^3.5.1",
     "backbone.radio": "^2.0.0",
-    "codemirror": "^5.65.21",
     "del": "^8.0.1",
     "glob": "^13.0.6",
     "gulp": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "handlebars": "^4.7.9",
     "jasmine": "^5.13.0",
     "jquery": "^4.0.0",
-    "jquery-ui": "^1.14.2",
     "jsdom": "^29.1.1",
     "mkdirp": "^3.0.1",
     "through2": "^5.0.5",

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -17,11 +17,12 @@ dependencies {
     // Served by Spring Boot's /webjars/** classpath mapping in the consuming app.
     // The platform manages jQuery, so its version lives in the Grails BOM rather
     // than here; the generated GSP resolves whatever the app's own dependency
-    // management settles on regardless (see WebjarVersions). Bootstrap is not in
-    // the BOM, so its versions stay in gradle.properties, read by both this build
-    // and gulp so the /webjars links it writes cannot drift.
+    // management settles on regardless (see WebjarVersions). Bootstrap and jQuery UI
+    // are not in the BOM, so their versions stay in gradle.properties, read by both
+    // this build and gulp so the /webjars links it writes cannot drift.
     runtimeOnly platform("org.apache.grails:grails-bom:$grailsVersion")
     runtimeOnly "org.webjars.npm:jquery"
+    runtimeOnly "org.webjars.npm:jquery-ui:${project.jqueryUiVersion}"
     runtimeOnly "org.webjars.npm:bootstrap:${project.bootstrapVersion}"
     runtimeOnly "org.webjars.npm:bootstrap-icons:${project.bootstrapIconsVersion}"
 

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -17,12 +17,13 @@ dependencies {
     // Served by Spring Boot's /webjars/** classpath mapping in the consuming app.
     // The platform manages jQuery, so its version lives in the Grails BOM rather
     // than here; the generated GSP resolves whatever the app's own dependency
-    // management settles on regardless (see WebjarVersions). Bootstrap and jQuery UI
+    // management settles on regardless (see WebjarVersions). Bootstrap, jQuery UI and CodeMirror
     // are not in the BOM, so their versions stay in gradle.properties, read by both
     // this build and gulp so the /webjars links it writes cannot drift.
     runtimeOnly platform("org.apache.grails:grails-bom:$grailsVersion")
     runtimeOnly "org.webjars.npm:jquery"
     runtimeOnly "org.webjars.npm:jquery-ui:${project.jqueryUiVersion}"
+    runtimeOnly "org.webjars.npm:codemirror:${project.codeMirrorVersion}"
     runtimeOnly "org.webjars.npm:bootstrap:${project.bootstrapVersion}"
     runtimeOnly "org.webjars.npm:bootstrap-icons:${project.bootstrapIconsVersion}"
 


### PR DESCRIPTION
Follows #21, which moved jQuery and Bootstrap to webjars. These were the two libraries left that were large enough to matter.

**jQuery UI** was 249K of the bundle, and it owned the only assets that needed the static-copy path: its base-theme stylesheet plus six theme images, copied purely so the stylesheet's relative `url()` references would resolve. Served from the jar they resolve for free, which empties `vendorStaticAssets` and lets that concept and its plumbing go.

**CodeMirror** was 401K — 59% of what remained. Core, groovy mode, core stylesheet and lesser-dark theme all come from the webjar now, with the mode emitted after the core it registers against.

The Grails BOM manages only `bootstrap`, `bootstrap-icons` and `jquery`, so both of these carry versions in `gradle.properties`, read by the Gradle build and by gulp so the generated `/webjars` links cannot drift — the same arrangement Bootstrap already uses.

### Why CodeMirror 5 and not 6

All the CodeMirror 6 packages are published as webjars, but the artifact is ES-module-only with bare specifiers — `codemirror@6/dist/index.js` opens with `import { ... } from '@codemirror/view'` and ships no UMD build — so a plain script tag cannot load it. It would need an import map covering the whole transitive graph, or a bundler. Separately, CodeMirror 6 is an API rewrite with no modes and different theming, so `web/app/editor` has to be rewritten regardless. That stays a project of its own.

### Result

Release payload falls from 1.0 MB in 13 files to **300K in 4**: the app bundle, the console's own stylesheet, jquery-layout's stylesheet and the favicon. Across #21 and this, it is down from 2.2 MB in 27 files.

### Verification

In the bundled app, after each change: every asset the page links returns 200, CodeMirror reports 5.65.21 with the groovy mode registered and highlighting rendering, jQuery 4.0.0 and jQuery UI 1.14.2 load with all six widgets present, a jQuery UI theme image referenced relatively from its stylesheet returns 200, the layout builds 5 panes, a script executes end to end, and no resource fails to load. 33 jasmine specs pass.

The README is updated to list all five webjars, note which the BOM manages, and extend the opt-out recipe and layout example — including the load order jQuery UI and the groovy mode depend on.