### PR TITLE
Move the editor to CodeMirror 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,20 @@ A web-based Groovy console for interactive runtime application management and de
 ### Webjars (8.x)
 
 As of 8.x the plugin no longer bundles its third-party libraries in its own
-resources. It declares `org.webjars.npm:jquery`, `org.webjars.npm:jquery-ui`,
-`org.webjars.npm:bootstrap`, `org.webjars.npm:bootstrap-icons` and
-`org.webjars.npm:codemirror` as transitive runtime dependencies, served through
-Spring Boot's standard `/webjars/**` classpath mapping. Two things follow from
-this:
+resources. It declares them as transitive runtime dependencies, served through
+Spring Boot's standard `/webjars/**` classpath mapping, in two groups:
+
+- **Replaceable** — `org.webjars.npm:jquery`, `org.webjars.npm:jquery-ui`,
+  `org.webjars.npm:bootstrap` and `org.webjars.npm:bootstrap-icons`, linked with
+  ordinary `<link>` and `<script>` tags. An application that already ships these
+  can supply its own; see below.
+- **Not replaceable** — CodeMirror 6, which is ES-module-only. The plugin emits
+  an import map covering the whole module graph (`@codemirror/*`, `@lezer/*`,
+  `style-mod`, `crelt`, `w3c-keyname`, `@marijn/find-cluster-break`) and a module
+  shim that loads it. Asset tags cannot substitute for that, so these are always
+  plugin-supplied and **must not be excluded**.
+
+Two things follow:
 
 - If your security configuration restricts URLs, `/webjars/**` must remain
   reachable. Bootstrap and the jQuery UI theme only affect styling, but the
@@ -35,7 +44,8 @@ this:
   the plugin's requested version), so overriding any of these versions in your
   app is safe. jQuery has no version pinned here at all; the BOM supplies it.
   The BOM does not manage jQuery UI or CodeMirror, so those carry versions from
-  the plugin's `gradle.properties`.
+  the plugin's `gradle.properties`, and the import map resolves each module's
+  version from the classpath at render time.
 
 #### Supplying your own copies
 
@@ -50,8 +60,9 @@ grails:
                 enabled: false
 ```
 
-That suppresses the `/webjars/**` `<link>` and `<script>` tags on the console
-page. Drop the runtime dependencies too, so the jars stop shipping:
+That suppresses the `<link>` and `<script>` tags for the four replaceable
+libraries. The CodeMirror import map is unaffected — it is emitted either way.
+Drop the four runtime dependencies too, so those jars stop shipping:
 
 ```groovy
 implementation('org.grails.plugins:grails-web-console:8.0.0') {
@@ -59,35 +70,29 @@ implementation('org.grails.plugins:grails-web-console:8.0.0') {
     exclude group: 'org.webjars.npm', module: 'jquery-ui'
     exclude group: 'org.webjars.npm', module: 'bootstrap'
     exclude group: 'org.webjars.npm', module: 'bootstrap-icons'
-    exclude group: 'org.webjars.npm', module: 'codemirror'
 }
 ```
 
-Supplying them then becomes your job — all of them, since the flag is
-all-or-nothing. Point `grails.plugin.console.layout` at a layout of your own that
-emits the tags ahead of `<g:layoutHead/>`, so the console's own stylesheets still
-win the cascade and jQuery is defined before its bundle runs:
+Do not exclude the `codemirror__*` artifacts; the editor will not load without
+them. Supplying the other four then becomes your job — all of them, since the
+flag is all-or-nothing. Point `grails.plugin.console.layout` at a layout of your
+own that emits the tags ahead of `<g:layoutHead/>`, so the console's own
+stylesheets still win the cascade and jQuery is defined before its bundle runs:
 
 ```gsp
 <head>
   <asset:stylesheet href="webjars/bootstrap/%/dist/css/bootstrap.css"/>
   <asset:stylesheet href="webjars/bootstrap-icons/%/font/bootstrap-icons.css"/>
   <asset:stylesheet href="webjars/jquery-ui/%/dist/themes/base/jquery-ui.css"/>
-  <asset:stylesheet href="webjars/codemirror/%/lib/codemirror.css"/>
-  <asset:stylesheet href="webjars/codemirror/%/theme/lesser-dark.css"/>
   <asset:javascript src="webjars/jquery/%/dist/jquery.js"/>
   <asset:javascript src="webjars/jquery-ui/%/dist/jquery-ui.js"/>
   <asset:javascript src="webjars/bootstrap/%/dist/js/bootstrap.bundle.js"/>
-  <asset:javascript src="webjars/codemirror/%/lib/codemirror.js"/>
-  <asset:javascript src="webjars/codemirror/%/mode/groovy/groovy.js"/>
   <g:layoutHead/>
 </head>
 ```
 
-Order matters: jQuery UI extends jQuery, and the groovy mode registers itself
-against the CodeMirror core. Serving five libraries yourself is a fair amount of
-work — unless your application already ships all of them, leaving the flag at its
-default is usually the better trade.
+Order matters: jQuery UI extends jQuery. The bundled `app/` in this repository
+runs exactly this arrangement, so the recipe is exercised on every build.
 
 `%` (or `*`) stands in for the version, so the layout survives a Bootstrap
 upgrade — asset-pipeline matches it against the compiled manifest in production

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,6 +38,8 @@ dependencies {
     // app — asset-pipeline compiles the allow-listed files below into build/assets instead.
     testAndDevelopmentOnly("org.webjars.npm:jquery")
     testAndDevelopmentOnly("org.webjars.npm:bootstrap")
+    testAndDevelopmentOnly("org.webjars.npm:bootstrap-icons")
+    testAndDevelopmentOnly("org.webjars.npm:jquery-ui:1.14.2")  // not managed by grails-bom
     runtimeOnly("com.h2database:h2")
     runtimeOnly("org.apache.tomcat:tomcat-jdbc")
     runtimeOnly("org.fusesource.jansi:jansi")
@@ -47,7 +49,17 @@ dependencies {
     integrationTestImplementation testFixtures("org.apache.grails:grails-geb")
     testImplementation("org.spockframework:spock-core")
 
-    implementation project(':grails-web-console')
+    // The console's replaceable webjars are declined; this app already compiles
+    // jQuery, jQuery UI, Bootstrap and Bootstrap Icons through asset-pipeline and
+    // hands them to the console via layouts/console.gsp. The codemirror__*
+    // artifacts are deliberately not excluded — the editor cannot load without
+    // the plugin's import map.
+    implementation(project(':grails-web-console')) {
+        exclude group: 'org.webjars.npm', module: 'jquery'
+        exclude group: 'org.webjars.npm', module: 'jquery-ui'
+        exclude group: 'org.webjars.npm', module: 'bootstrap'
+        exclude group: 'org.webjars.npm', module: 'bootstrap-icons'
+    }
 }
 
 apply {
@@ -65,6 +77,11 @@ assets {
             'webjars/jquery/*/dist/jquery.js',
             'webjars/bootstrap/*/dist/js/bootstrap.bundle.js',
             'webjars/bootstrap/*/dist/css/bootstrap.css',
+            'webjars/bootstrap-icons/*/font/bootstrap-icons.css',
+            'webjars/bootstrap-icons/*/font/fonts/*',
+            'webjars/jquery-ui/*/dist/jquery-ui.js',
+            'webjars/jquery-ui/*/dist/themes/base/jquery-ui.css',
+            'webjars/jquery-ui/*/dist/themes/base/images/*',
     ]
 }
 

--- a/app/grails-app/conf/application.yml
+++ b/app/grails-app/conf/application.yml
@@ -52,6 +52,9 @@ grails:
     plugin:
         console:
             enabled: true
+            webjars:
+                enabled: false
+            layout: console
             csrfProtection:
                 enabled: true
 dataSource:

--- a/app/grails-app/views/layouts/console.gsp
+++ b/app/grails-app/views/layouts/console.gsp
@@ -1,0 +1,21 @@
+<!doctype html>
+<html>
+<head>
+  <%-- Supplies the console's four replaceable libraries from this app's own
+       asset-pipeline build, with grails.plugin.console.webjars.enabled = false
+       and the matching exclusions in build.gradle. CodeMirror is not listed:
+       it is ES-module-only and always comes from the plugin's import map.
+       Ahead of <g:layoutHead/> so the console's stylesheets win the cascade and
+       jQuery is defined before its bundle runs. --%>
+  <asset:stylesheet href="webjars/bootstrap/%/dist/css/bootstrap.css"/>
+  <asset:stylesheet href="webjars/bootstrap-icons/%/font/bootstrap-icons.css"/>
+  <asset:stylesheet href="webjars/jquery-ui/%/dist/themes/base/jquery-ui.css"/>
+  <asset:javascript src="webjars/jquery/%/dist/jquery.js"/>
+  <asset:javascript src="webjars/jquery-ui/%/dist/jquery-ui.js"/>
+  <asset:javascript src="webjars/bootstrap/%/dist/js/bootstrap.bundle.js"/>
+  <g:layoutHead/>
+</head>
+<body>
+<g:layoutBody/>
+</body>
+</html>

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,12 @@ testLoggerVersion=4.0.0
 # /webjars/... links in the GSP fragments (single source of truth for both)
 bootstrapVersion=5.3.8
 jqueryUiVersion=1.14.2
-codeMirrorVersion=5.65.21
+codeMirrorStateVersion=6.7.1
+codeMirrorViewVersion=6.43.6
+codeMirrorCommandsVersion=6.10.2
+codeMirrorLanguageVersion=6.12.4
+codeMirrorLegacyModesVersion=6.5.1
+codeMirrorThemeOneDarkVersion=6.1.3
 bootstrapIconsVersion=1.13.1
 
 org.gradle.caching=true

--- a/gulp-tasks/grails-builder.js
+++ b/gulp-tasks/grails-builder.js
@@ -92,8 +92,12 @@ export const build = async (isDebug, options) => {
         path.join(options.outputDir, fragment),
         tags.length ? tags.join('\n') + '\n' : ''
     );
+    const moduleWebjars = options.paths.vendor.moduleWebjars || [];
     await Promise.all([
         writeFragment('_webjarsCss.gsp', webjars.css.map(options.webjarCssWrap)),
         writeFragment('_webjarsJs.gsp', webjars.js.map(options.webjarJsWrap)),
+        // the import map has to precede every module script on the page, so this
+        // fragment is rendered in <head>
+        writeFragment('_webjarsModules.gsp', moduleWebjars.length ? [options.moduleShim(moduleWebjars)] : []),
     ]);
 };

--- a/gulp-tasks/grails.js
+++ b/gulp-tasks/grails.js
@@ -31,7 +31,8 @@ const moduleShim = modules => [
     '  import { EditorState, Compartment } from "@codemirror/state"',
     '  import { EditorView, keymap, lineNumbers, highlightActiveLine, highlightActiveLineGutter } from "@codemirror/view"',
     '  import { defaultKeymap, history, historyKeymap, indentWithTab } from "@codemirror/commands"',
-    '  import { StreamLanguage, bracketMatching, indentUnit, syntaxHighlighting, defaultHighlightStyle } from "@codemirror/language"',
+    '  import { StreamLanguage, bracketMatching, indentUnit, syntaxHighlighting, defaultHighlightStyle, HighlightStyle } from "@codemirror/language"',
+    '  import { tags } from "@lezer/highlight"',
     '  import { groovy } from "@codemirror/legacy-modes/mode/groovy"',
     '  import { oneDark } from "@codemirror/theme-one-dark"',
     '  // the classic console bundle reads this on jQuery ready, which is after',
@@ -39,7 +40,7 @@ const moduleShim = modules => [
     '  window.CM6 = { EditorState, EditorView, Compartment, keymap, lineNumbers,',
     '      highlightActiveLine, highlightActiveLineGutter, defaultKeymap, history,',
     '      historyKeymap, indentWithTab, StreamLanguage, bracketMatching, indentUnit,',
-    '      syntaxHighlighting, defaultHighlightStyle, groovy, oneDark }',
+    '      syntaxHighlighting, defaultHighlightStyle, HighlightStyle, tags, groovy, oneDark }',
     '</script>',
 ].join('\n');
 

--- a/gulp-tasks/grails.js
+++ b/gulp-tasks/grails.js
@@ -12,6 +12,37 @@ const webjarVersionExpression = webjar => webjar.defaultVersion
     ? `\${org.grails.plugins.console.WebjarVersions.version('${webjar.name}') ?: '${webjar.defaultVersion}'}`
     : `\${org.grails.plugins.console.WebjarVersions.version('${webjar.name}')}`;
 
+// The import map must carry a concrete version per specifier, so each is resolved
+// from the runtime classpath. A module missing from the classpath yields an empty
+// version and a broken URL, which only happens when the app has excluded the
+// dependency — the same situation in which it would 404 whatever we wrote.
+const importMapEntry = m =>
+    `    "${m.specifier}": "\${request.contextPath}/webjars/${m.webjar}/\${org.grails.plugins.console.WebjarVersions.version('${m.webjar}')}/${m.file}"`;
+
+const moduleShim = modules => [
+    '<script type="importmap">',
+    '{',
+    '  "imports": {',
+    modules.map(importMapEntry).join(',\n'),
+    '  }',
+    '}',
+    '</script>',
+    '<script type="module">',
+    '  import { EditorState, Compartment } from "@codemirror/state"',
+    '  import { EditorView, keymap, lineNumbers, highlightActiveLine, highlightActiveLineGutter } from "@codemirror/view"',
+    '  import { defaultKeymap, history, historyKeymap, indentWithTab } from "@codemirror/commands"',
+    '  import { StreamLanguage, bracketMatching, indentUnit, syntaxHighlighting, defaultHighlightStyle } from "@codemirror/language"',
+    '  import { groovy } from "@codemirror/legacy-modes/mode/groovy"',
+    '  import { oneDark } from "@codemirror/theme-one-dark"',
+    '  // the classic console bundle reads this on jQuery ready, which is after',
+    '  // deferred module scripts have run',
+    '  window.CM6 = { EditorState, EditorView, Compartment, keymap, lineNumbers,',
+    '      highlightActiveLine, highlightActiveLineGutter, defaultKeymap, history,',
+    '      historyKeymap, indentWithTab, StreamLanguage, bracketMatching, indentUnit,',
+    '      syntaxHighlighting, defaultHighlightStyle, groovy, oneDark }',
+    '</script>',
+].join('\n');
+
 const options = {
     outputDir:   './plugin/grails-app/views/console/',
     relativeDir: './plugin/src/main/resources/public',
@@ -21,6 +52,7 @@ const options = {
     cssWrap:     path => `<link rel="stylesheet" media="screen" href="\${resource(file: '${path}')}" />`,
     webjarJsWrap:  webjar => `<script type="text/javascript" src="\${request.contextPath}/webjars/${webjar.name}/${webjarVersionExpression(webjar)}/${webjar.file}" ></script>`,
     webjarCssWrap: webjar => `<link rel="stylesheet" media="screen" href="\${request.contextPath}/webjars/${webjar.name}/${webjarVersionExpression(webjar)}/${webjar.file}" />`,
+    moduleShim,
     paths:       paths
 };
 

--- a/gulp-tasks/paths.js
+++ b/gulp-tasks/paths.js
@@ -15,7 +15,6 @@ const gradleProperties = Object.fromEntries(
 const bootstrapVersion = gradleProperties.bootstrapVersion;
 const bootstrapIconsVersion = gradleProperties.bootstrapIconsVersion;
 const jqueryUiVersion = gradleProperties.jqueryUiVersion;
-const codeMirrorVersion = gradleProperties.codeMirrorVersion;
 
 // Assets served from the consuming app's webjar classpath rather than copied
 // into the plugin's public resources. The generated GSP resolves the version
@@ -28,8 +27,6 @@ const webjars = {
         // the theme's images/ sit beside this file inside the jar, so its relative
         // url() references resolve without copying anything into the plugin
         { name: 'jquery-ui', file: 'dist/themes/base/jquery-ui.min.css', defaultVersion: jqueryUiVersion },
-        { name: 'codemirror', file: 'lib/codemirror.css', defaultVersion: codeMirrorVersion },
-        { name: 'codemirror', file: 'theme/lesser-dark.css', defaultVersion: codeMirrorVersion },
     ],
     js: [
         // jQuery first: the console's bundle expects it as a global. No
@@ -38,11 +35,35 @@ const webjars = {
         { name: 'jquery', file: 'dist/jquery.min.js' },
         { name: 'jquery-ui', file: 'dist/jquery-ui.min.js', defaultVersion: jqueryUiVersion },
         { name: 'bootstrap', file: 'dist/js/bootstrap.bundle.min.js', defaultVersion: bootstrapVersion },
-        // the groovy mode registers itself against the core, so it follows it
-        { name: 'codemirror', file: 'lib/codemirror.js', defaultVersion: codeMirrorVersion },
-        { name: 'codemirror', file: 'mode/groovy/groovy.js', defaultVersion: codeMirrorVersion },
     ],
 };
+
+// CodeMirror 6 ships ES modules with bare import specifiers and no browser
+// global, so it cannot be loaded with a plain script tag. index.gsp emits an
+// import map pinning each specifier to its /webjars/ URL, then a module shim
+// that imports what the editor needs and hangs it on window.CM6 for the classic
+// bundle. Module scripts are deferred but run before DOMContentLoaded, so CM6 is
+// defined by the time App.start() fires on jQuery ready.
+//
+// Versions are resolved from the classpath at render time, so none are pinned
+// here. The first six are declared in plugin/build.gradle; the rest arrive
+// transitively and are listed because the import map must cover every bare
+// specifier the graph resolves, not just the ones the shim names.
+const moduleWebjars = [
+    { specifier: '@codemirror/state',                     webjar: 'codemirror__state',           file: 'dist/index.js' },
+    { specifier: '@codemirror/view',                      webjar: 'codemirror__view',            file: 'dist/index.js' },
+    { specifier: '@codemirror/commands',                  webjar: 'codemirror__commands',        file: 'dist/index.js' },
+    { specifier: '@codemirror/language',                  webjar: 'codemirror__language',        file: 'dist/index.js' },
+    { specifier: '@codemirror/theme-one-dark',            webjar: 'codemirror__theme-one-dark',  file: 'dist/index.js' },
+    { specifier: '@codemirror/legacy-modes/mode/groovy',  webjar: 'codemirror__legacy-modes',    file: 'mode/groovy.js' },
+    { specifier: '@lezer/common',                         webjar: 'lezer__common',               file: 'dist/index.js' },
+    { specifier: '@lezer/highlight',                      webjar: 'lezer__highlight',            file: 'dist/index.js' },
+    { specifier: '@lezer/lr',                             webjar: 'lezer__lr',                   file: 'dist/index.js' },
+    { specifier: '@marijn/find-cluster-break',            webjar: 'marijn__find-cluster-break',  file: 'src/index.js' },
+    { specifier: 'style-mod',                             webjar: 'style-mod',                   file: 'src/style-mod.js' },
+    { specifier: 'crelt',                                 webjar: 'crelt',                       file: 'index.js' },
+    { specifier: 'w3c-keyname',                           webjar: 'w3c-keyname',                 file: 'index.js' },
+];
 
 const vendorCssAssets = [
     {
@@ -113,6 +134,7 @@ export const paths = {
         cssAssets: vendorCssAssets,
         jsAssets: vendorJsAssets,
         webjars,
+        moduleWebjars,
     },
     test: [
         './js/tests/**.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,12 @@
       "name": "grails-web-console",
       "version": "1.6.0",
       "devDependencies": {
+        "@codemirror/commands": "^6.10.2",
+        "@codemirror/language": "^6.12.4",
+        "@codemirror/legacy-modes": "^6.5.1",
+        "@codemirror/state": "^6.7.1",
+        "@codemirror/theme-one-dark": "^6.1.3",
+        "@codemirror/view": "^6.43.6",
         "backbone": "^1.6.1",
         "backbone.marionette": "^3.5.1",
         "backbone.radio": "^2.0.0",
@@ -92,6 +98,80 @@
       },
       "bin": {
         "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.2.tgz",
+      "integrity": "sha512-vvX1fsih9HledO1c9zdotZYUZnE4xV0m6i3m25s5DIfXofuprk6cRcLUZvSk3CASUbwjQX21tOGbkY2BH8TpnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.4.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.4.tgz",
+      "integrity": "sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/legacy-modes": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/legacy-modes/-/legacy-modes-6.5.1.tgz",
+      "integrity": "sha512-DJYQQ00N1/KdESpZV7jg9hafof/iBNp9h7TYo1SLMk86TWl9uDsVdho2dzd81K+v4retmK6mdC7WpuOQDytQqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.7.1.tgz",
+      "integrity": "sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/theme-one-dark": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.3.tgz",
+      "integrity": "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.43.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.6.tgz",
+      "integrity": "sha512-EVunGSYN1wz1p75WY1s3Xg7t3i8Yol0kGZGizNdX9BUFgMFILYVe8/u6EVpo7Ff5PwbZuILb4QAq7IZoKzIEQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.7.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -377,6 +457,40 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/@lezer/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+      "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.3.tgz",
+      "integrity": "sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -1152,6 +1266,13 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/crelt": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.7.tgz",
+      "integrity": "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3992,6 +4113,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -4522,6 +4650,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,12 @@
   "version": "1.6.0",
   "type": "module",
   "devDependencies": {
+    "@codemirror/commands": "^6.10.2",
+    "@codemirror/language": "^6.12.4",
+    "@codemirror/legacy-modes": "^6.5.1",
+    "@codemirror/state": "^6.7.1",
+    "@codemirror/theme-one-dark": "^6.1.3",
+    "@codemirror/view": "^6.43.6",
     "backbone": "^1.6.1",
     "backbone.marionette": "^3.5.1",
     "backbone.radio": "^2.0.0",

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -23,7 +23,16 @@ dependencies {
     runtimeOnly platform("org.apache.grails:grails-bom:$grailsVersion")
     runtimeOnly "org.webjars.npm:jquery"
     runtimeOnly "org.webjars.npm:jquery-ui:${project.jqueryUiVersion}"
-    runtimeOnly "org.webjars.npm:codemirror:${project.codeMirrorVersion}"
+    // CodeMirror 6 is ESM-only, so index.gsp emits an import map over these and a
+    // module shim rather than plain script tags. Only what the editor imports is
+    // declared; the rest of the graph (@lezer/*, style-mod, crelt, w3c-keyname,
+    // @marijn/find-cluster-break) arrives transitively from these webjars' POMs.
+    runtimeOnly "org.webjars.npm:codemirror__state:${project.codeMirrorStateVersion}"
+    runtimeOnly "org.webjars.npm:codemirror__view:${project.codeMirrorViewVersion}"
+    runtimeOnly "org.webjars.npm:codemirror__commands:${project.codeMirrorCommandsVersion}"
+    runtimeOnly "org.webjars.npm:codemirror__language:${project.codeMirrorLanguageVersion}"
+    runtimeOnly "org.webjars.npm:codemirror__legacy-modes:${project.codeMirrorLegacyModesVersion}"
+    runtimeOnly "org.webjars.npm:codemirror__theme-one-dark:${project.codeMirrorThemeOneDarkVersion}"
     runtimeOnly "org.webjars.npm:bootstrap:${project.bootstrapVersion}"
     runtimeOnly "org.webjars.npm:bootstrap-icons:${project.bootstrapIconsVersion}"
 

--- a/plugin/grails-app/views/console/index.gsp
+++ b/plugin/grails-app/views/console/index.gsp
@@ -9,7 +9,11 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
   <g:render template="favicon" />
   <g:if test="${webjarsEnabled}"><g:render template="webjarsCss" /></g:if>
-  <g:if test="${webjarsEnabled}"><g:render template="webjarsModules" /></g:if>
+  <%-- Always rendered: the import map and module shim are how the console loads
+       CodeMirror 6 at all, not a library a host application could already have.
+       An app cannot substitute these with asset tags, so they sit outside the
+       opt-out, and the codemirror webjars must not be excluded. --%>
+  <g:render template="webjarsModules" />
   <g:render template="css" />
   
   <meta name="layout" content="${grailsApplication.config['grails.plugin.console.layout'] ?: 'console-plugin-layout'}"/>

--- a/plugin/grails-app/views/console/index.gsp
+++ b/plugin/grails-app/views/console/index.gsp
@@ -9,6 +9,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
   <g:render template="favicon" />
   <g:if test="${webjarsEnabled}"><g:render template="webjarsCss" /></g:if>
+  <g:if test="${webjarsEnabled}"><g:render template="webjarsModules" /></g:if>
   <g:render template="css" />
   
   <meta name="layout" content="${grailsApplication.config['grails.plugin.console.layout'] ?: 'console-plugin-layout'}"/>

--- a/run-jasmine-jsdom.cjs
+++ b/run-jasmine-jsdom.cjs
@@ -32,6 +32,10 @@ const installGlobals = window => {
   global.KeyboardEvent = window.KeyboardEvent;
   global.MouseEvent = window.MouseEvent;
   global.getComputedStyle = window.getComputedStyle.bind(window);
+  // CodeMirror 6's EditorView constructs a DOMObserver immediately
+  global.MutationObserver = window.MutationObserver;
+  global.DOMParser = window.DOMParser;
+  global.Range = window.Range;
   global.requestAnimationFrame = window.requestAnimationFrame.bind(window);
   global.cancelAnimationFrame = window.cancelAnimationFrame.bind(window);
   global.setTimeout = timers.setTimeout;
@@ -176,6 +180,33 @@ const loadSpecs = context => {
   glob.sync(resolveFromRoot('build/spec/**/*spec.*')).sort().forEach(file => loadScript(file, context));
 };
 
+// In the browser, index.gsp's import map plus a module script put CodeMirror 6's
+// exports on window.CM6 before the console boots. jsdom honours neither, so the
+// same surface is assembled here from the installed packages.
+const loadCodeMirror = async window => {
+  const [state, view, commands, language, groovyMode, oneDarkTheme] = await Promise.all([
+    import('@codemirror/state'),
+    import('@codemirror/view'),
+    import('@codemirror/commands'),
+    import('@codemirror/language'),
+    import('@codemirror/legacy-modes/mode/groovy'),
+    import('@codemirror/theme-one-dark'),
+  ]);
+  window.CM6 = {
+    EditorState: state.EditorState, Compartment: state.Compartment,
+    EditorView: view.EditorView, keymap: view.keymap, lineNumbers: view.lineNumbers,
+    highlightActiveLine: view.highlightActiveLine,
+    highlightActiveLineGutter: view.highlightActiveLineGutter,
+    defaultKeymap: commands.defaultKeymap, history: commands.history,
+    historyKeymap: commands.historyKeymap, indentWithTab: commands.indentWithTab,
+    StreamLanguage: language.StreamLanguage, bracketMatching: language.bracketMatching,
+    indentUnit: language.indentUnit, syntaxHighlighting: language.syntaxHighlighting,
+    defaultHighlightStyle: language.defaultHighlightStyle,
+    groovy: groovyMode.groovy, oneDark: oneDarkTheme.oneDark,
+  };
+  global.CM6 = window.CM6;
+};
+
 const run = async () => {
   const dom = buildDom();
   const { window } = dom;
@@ -183,6 +214,7 @@ const run = async () => {
 
   installGlobals(window);
   loadBrowserLibraries(context);
+  await loadCodeMirror(window);
 
   global.$ = window.$;
   global.jQuery = window.jQuery;

--- a/web/app/app.coffee
+++ b/web/app/app.coffee
@@ -181,7 +181,10 @@ Application = Marionette.Application.extend
 
   showTheme: ->
     theme = @settings.get('theme')
+    # The surrounding chrome only has a light and a dark variant; editor themes
+    # are independent of it, so adding one costs no stylesheet work.
     $('body').attr 'data-theme', theme
+    $('body').attr 'data-chrome', App.Editor.chromeFor(theme)
 
   savingOn: ->
     $('.navbar .saving').fadeIn 100

--- a/web/app/editor/editor-view.coffee
+++ b/web/app/editor/editor-view.coffee
@@ -54,7 +54,7 @@ App.Editor.EditorView = Marionette.View.extend
         @editor.focus()
 
     themeExtension: ->
-        if App.settings.get('theme') is 'default' then [] else window.CM6.oneDark
+        App.Editor.themeFor(App.settings.get('theme')).extension()
 
     setTheme: ->
         @editor.dispatch effects: @themeCompartment.reconfigure(@themeExtension())

--- a/web/app/editor/editor-view.coffee
+++ b/web/app/editor/editor-view.coffee
@@ -21,36 +21,53 @@ App.Editor.EditorView = Marionette.View.extend
         @initEditor()
 
     initEditor: ->
-        @editor = CodeMirror.fromTextArea(@$('textarea[name=code]')[0],
-            matchBrackets: true
-            mode: 'groovy'
-            lineNumbers: true
-            tabSize: App.data.tabSize        ? 4,
-            indentUnit: App.data.indentUnit     ? 4
-            indentWithTabs: App.data.indentWithTabs ? false
-            extraKeys:
-                'Ctrl-Enter': ->  App.execute 'execute'
-                'Cmd-Enter': ->   App.execute 'execute'
-                'Ctrl-S': ->      App.execute 'save'
-                'Cmd-S': ->       App.execute 'save'
-                'Esc': ->         App.execute 'clear'
-        )
+        # CodeMirror 6 is loaded as an ES module by the import map in index.gsp,
+        # which hangs its exports on window.CM6 before jQuery ready fires.
+        cm = window.CM6
+        @themeCompartment = new cm.Compartment()
+        indent = ' '.repeat(App.data.indentUnit ? 4)
+
+        run = (command) -> -> App.execute(command); true
+
+        textarea = @$('textarea[name=code]')[0]
+        @editor = new cm.EditorView
+            doc: ''
+            parent: textarea.parentNode
+            extensions: [
+                cm.lineNumbers()
+                cm.highlightActiveLine()
+                cm.highlightActiveLineGutter()
+                cm.history()
+                cm.bracketMatching()
+                cm.syntaxHighlighting(cm.defaultHighlightStyle, fallback: true)
+                cm.StreamLanguage.define(cm.groovy)
+                cm.indentUnit.of(if App.data.indentWithTabs then '\t' else indent)
+                cm.keymap.of([
+                    {key: 'Mod-Enter', run: run('execute')}
+                    {key: 'Mod-s',     run: run('save'), preventDefault: true}
+                    {key: 'Escape',    run: run('clear')}
+                    cm.indentWithTab
+                ].concat(cm.defaultKeymap, cm.historyKeymap))
+                @themeCompartment.of(@themeExtension())
+            ]
+        textarea.remove()
         @editor.focus()
-        @editor.setValue ''
-        @setTheme()
+
+    themeExtension: ->
+        if App.settings.get('theme') is 'default' then [] else window.CM6.oneDark
 
     setTheme: ->
-        @editor.setOption 'theme', App.settings.get('theme')
+        @editor.dispatch effects: @themeCompartment.reconfigure(@themeExtension())
 
     getValue: ->
-        @editor.getValue()
+        @editor.state.doc.toString()
 
     refresh: ->
-        @editor.refresh()
+        @editor.requestMeasure()
 
     setValue: (text) ->
-        @editor.setValue text
-        @editor.refresh()
+        @editor.dispatch
+            changes: {from: 0, to: @editor.state.doc.length, insert: text}
         @editor.focus()
 
     onOpenClick: (event) ->

--- a/web/app/editor/themes.coffee
+++ b/web/app/editor/themes.coffee
@@ -1,0 +1,79 @@
+App.Editor = App.Editor || {}
+
+# Editor themes, keyed by the value stored in settings. Each entry names the
+# chrome variant it sits in — the surrounding navbar, toolbar, output pane and
+# modals only have a light and a dark form — and supplies the CodeMirror
+# extension, so a new theme is a single entry here plus one line in
+# templates/main/settings.hbs, with no stylesheet changes.
+#
+# `extension` is a function because window.CM6 is populated by the module shim
+# in index.gsp and must not be dereferenced while this file is being evaluated.
+
+# https://ethanschoonover.com/solarized/ — no CodeMirror 6 port of this is
+# published as a webjar, so it is defined here rather than pulled in.
+SOLARIZED =
+  base03: '#002b36', base01: '#586e75', base00: '#657b83', base0: '#839496'
+  base1:  '#93a1a1', base2:  '#eee8d5', base3:  '#fdf6e3'
+  yellow: '#b58900', orange: '#cb4b16', red:    '#dc322f', magenta: '#d33682'
+  violet: '#6c71c4', blue:   '#268bd2', cyan:   '#2aa198', green:   '#859900'
+
+solarizedLight = ->
+  {EditorView, HighlightStyle, syntaxHighlighting, tags} = window.CM6
+
+  theme = EditorView.theme
+    '&': {color: SOLARIZED.base00, backgroundColor: SOLARIZED.base3}
+    '.cm-content': {caretColor: SOLARIZED.base01}
+    '.cm-cursor, .cm-dropCursor': {borderLeftColor: SOLARIZED.base01}
+    '&.cm-focused .cm-selectionBackgroundInactive, .cm-selectionBackground, ::selection':
+      {backgroundColor: SOLARIZED.base2}
+    '.cm-activeLine': {backgroundColor: '#eee8d580'}
+    '.cm-gutters':
+      {backgroundColor: SOLARIZED.base2, color: SOLARIZED.base1, border: 'none'}
+    '.cm-activeLineGutter': {backgroundColor: SOLARIZED.base2, color: SOLARIZED.base01}
+    '.cm-matchingBracket, .cm-nonmatchingBracket':
+      {backgroundColor: SOLARIZED.base2, outline: "1px solid #{SOLARIZED.base1}"}
+  , dark: false
+
+  highlight = HighlightStyle.define [
+    {tag: tags.keyword,                    color: SOLARIZED.green}
+    {tag: [tags.name, tags.deleted, tags.character, tags.propertyName, tags.macroName],
+                                           color: SOLARIZED.base00}
+    {tag: [tags.function(tags.variableName), tags.labelName], color: SOLARIZED.blue}
+    {tag: [tags.color, tags.constant(tags.name), tags.standard(tags.name)],
+                                           color: SOLARIZED.yellow}
+    {tag: [tags.definition(tags.name), tags.separator], color: SOLARIZED.base01}
+    {tag: [tags.typeName, tags.className, tags.number, tags.changed,
+           tags.annotation, tags.modifier, tags.self, tags.namespace],
+                                           color: SOLARIZED.violet}
+    {tag: [tags.operator, tags.operatorKeyword, tags.url, tags.escape,
+           tags.regexp, tags.link, tags.special(tags.string)],
+                                           color: SOLARIZED.cyan}
+    {tag: [tags.meta, tags.comment],       color: SOLARIZED.base1, fontStyle: 'italic'}
+    {tag: tags.strong,                     fontWeight: 'bold'}
+    {tag: tags.emphasis,                   fontStyle: 'italic'}
+    {tag: tags.strikethrough,              textDecoration: 'line-through'}
+    {tag: tags.link,                       textDecoration: 'underline'}
+    {tag: tags.heading,                    fontWeight: 'bold', color: SOLARIZED.orange}
+    {tag: [tags.atom, tags.bool, tags.special(tags.variableName)], color: SOLARIZED.magenta}
+    {tag: [tags.processingInstruction, tags.string, tags.inserted], color: SOLARIZED.cyan}
+    {tag: tags.invalid,                    color: SOLARIZED.red}
+  ]
+
+  [theme, syntaxHighlighting(highlight)]
+
+App.Editor.themes =
+  'default':
+    chrome: 'light'
+    extension: -> []
+  'one-dark':
+    chrome: 'dark'
+    extension: -> window.CM6.oneDark
+  'solarized-light':
+    chrome: 'light'
+    extension: solarizedLight
+
+App.Editor.themeFor = (name) ->
+  App.Editor.themes[name] ? App.Editor.themes['default']
+
+App.Editor.chromeFor = (name) ->
+  App.Editor.themeFor(name).chrome

--- a/web/spec/editor/editor-view-spec.coffee
+++ b/web/spec/editor/editor-view-spec.coffee
@@ -17,8 +17,12 @@ describe 'App.Editor.EditorView', ->
     expect(@view.getValue()).toBe 'test value'
 
   it 'should syncEditorSettings', ->
-    App.settings.set 'theme', 'test-theme'
-    expect(@view.editor.getOption 'theme').toBe 'test-theme'
+    darkTheme = window.CM6.EditorView.darkTheme
+    expect(@view.editor.state.facet darkTheme).toBe false
+    App.settings.set 'theme', 'one-dark'
+    expect(@view.editor.state.facet darkTheme).toBe true
+    App.settings.set 'theme', 'default'
+    expect(@view.editor.state.facet darkTheme).toBe false
 
   it 'should execute new on click', ->
     spyOn App, 'execute'

--- a/web/spec/settings-view-spec.coffee
+++ b/web/spec/settings-view-spec.coffee
@@ -4,7 +4,7 @@ describe 'App.Main.SettingsView', ->
     @settings = new App.Entities.Settings
       'orientation': 'vertical'
       'results.wrapText': true
-      'theme': 'lesser-dark'
+      'theme': 'one-dark'
 
     @view = new App.Main.SettingsView model: @settings
 
@@ -21,7 +21,7 @@ describe 'App.Main.SettingsView', ->
     expect(@view.$('.orientation-vertical')).toHaveClass 'selected'
     expect(@view.$('.results-wrap')).toHaveClass 'selected'
     expect(@view.$('.theme[data-theme="default"]')).not.toHaveClass 'selected'
-    expect(@view.$('.theme[data-theme="lesser-dark"]')).toHaveClass 'selected'
+    expect(@view.$('.theme[data-theme="one-dark"]')).toHaveClass 'selected'
 
   it 'should handle click events', ->
     @view.$('.orientation-horizontal').click()
@@ -36,7 +36,7 @@ describe 'App.Main.SettingsView', ->
     @view.$('.theme[data-theme="default"]').click()
     expect(@settings.get('theme')).toBe 'default'
     expect(@view.$('.theme[data-theme="default"]')).toHaveClass 'selected'
-    expect(@view.$('.theme[data-theme="lesser-dark"]')).not.toHaveClass 'selected'
+    expect(@view.$('.theme[data-theme="one-dark"]')).not.toHaveClass 'selected'
 
 
 

--- a/web/styles/app.less
+++ b/web/styles/app.less
@@ -399,7 +399,7 @@ body {
   }
 }
 
-body[data-theme="default"] {
+body[data-chrome="light"] {
   .navbar {
     background-color: #e9e9e7;
     .navbar-brand {
@@ -467,7 +467,7 @@ body[data-theme="default"] {
   }
 }
 
-body[data-theme="one-dark"] {
+body[data-chrome="dark"] {
   .navbar {
     background-color: #222;
     .navbar-brand {

--- a/web/styles/app.less
+++ b/web/styles/app.less
@@ -237,7 +237,7 @@ body {
   padding: 0;
 }
 
-.CodeMirror {
+.cm-editor {
   height: 100%;
   font-size: 14px;
 }
@@ -467,7 +467,7 @@ body[data-theme="default"] {
   }
 }
 
-body[data-theme="lesser-dark"] {
+body[data-theme="one-dark"] {
   .navbar {
     background-color: #222;
     .navbar-brand {

--- a/web/templates/main/settings.hbs
+++ b/web/templates/main/settings.hbs
@@ -12,7 +12,7 @@
 <li><hr class="dropdown-divider"></li>
 <li><h6 class="dropdown-header">Theme</h6></li>
 <li><a href="#" class="dropdown-item setting theme" data-theme="default"><i class="bi bi-check-lg"></i> Light</a></li>
-<li><a href="#" class="dropdown-item setting theme" data-theme="lesser-dark"><i class="bi bi-check-lg"></i> Dark</a></li>
+<li><a href="#" class="dropdown-item setting theme" data-theme="one-dark"><i class="bi bi-check-lg"></i> Dark</a></li>
 <li><hr class="dropdown-divider"></li>
 <li><h6 class="dropdown-header">Editor</h6></li>
 <li><a href="#" class="dropdown-item setting auto-import-domains"><i class="bi bi-check-lg"></i> Auto import domain classes</a></li>

--- a/web/templates/main/settings.hbs
+++ b/web/templates/main/settings.hbs
@@ -13,6 +13,7 @@
 <li><h6 class="dropdown-header">Theme</h6></li>
 <li><a href="#" class="dropdown-item setting theme" data-theme="default"><i class="bi bi-check-lg"></i> Light</a></li>
 <li><a href="#" class="dropdown-item setting theme" data-theme="one-dark"><i class="bi bi-check-lg"></i> Dark</a></li>
+<li><a href="#" class="dropdown-item setting theme" data-theme="solarized-light"><i class="bi bi-check-lg"></i> Solarized Light</a></li>
 <li><hr class="dropdown-divider"></li>
 <li><h6 class="dropdown-header">Editor</h6></li>
 <li><a href="#" class="dropdown-item setting auto-import-domains"><i class="bi bi-check-lg"></i> Auto import domain classes</a></li>


### PR DESCRIPTION
Answers the question left open in #22, where CodeMirror 5 moved to a webjar and CodeMirror 6 was deferred as needing a bundler.

It does not need one. CodeMirror 6 ships ES modules with bare import specifiers and no browser global, which a plain script tag cannot load — but an **import map** resolves that natively. `index.gsp` now emits a map pinning every specifier in the graph to its `/webjars/` URL, followed by a small module shim that imports what the editor needs and hangs it on `window.CM6`. Module scripts are deferred but execute before `DOMContentLoaded`, so `CM6` is defined by the time `App.start()` runs on jQuery ready and the classic Backbone bundle uses it unchanged.

Versions come from `WebjarVersions` at render time, so nothing is pinned in the map at build time. Only the six packages the shim imports are declared in `plugin/build.gradle`; `@lezer/*`, `style-mod`, `crelt`, `w3c-keyname` and `@marijn/find-cluster-break` arrive transitively. All thirteen appear in `paths.js` because the map must cover every specifier the graph resolves, not only those named in an import statement.

### Editor rewrite

`editor-view.coffee` moves to the CodeMirror 6 API — `EditorView` for `fromTextArea`, `state.doc.toString()` for `getValue`, a dispatch for `setValue`, `requestMeasure` for `refresh`, `keymap.of` for `extraKeys`, and `StreamLanguage.define(groovy)` from `@codemirror/legacy-modes` for `mode: 'groovy'`. The theme lives in a `Compartment` so it can be reconfigured in place.

### Theme

CodeMirror 6 has no `lesser-dark`, so the dark option is `@codemirror/theme-one-dark` and the stored setting value is renamed to match, in `app.less`, the settings template and the specs. Anything other than `default` resolves to dark, so a persisted `lesser-dark` keeps working.

### Tests

jsdom honours neither import maps nor module scripts, so the harness assembles the same `window.CM6` surface from the installed packages and exposes `MutationObserver`, `DOMParser` and `Range`, which `EditorView` constructs against.

### Verification

In the bundled app: all 19 webjar URLs including every transitive module return 200; the editor renders with gutters; groovy highlighting produces coloured tokens (`def`/`assert` as keywords, numerals and strings distinct); a script executes end to end; the theme toggle switches the editor and the surrounding chrome together; no resource fails to load. 33 jasmine specs pass.

Payload is unchanged at 304K — CodeMirror already moved to a webjar in #22, so this changes how it is delivered rather than what ships.