### PR TITLE
Add Solarized Dark and Dracula editor themes

### DIFF
--- a/web/app/editor/themes.coffee
+++ b/web/app/editor/themes.coffee
@@ -8,69 +8,115 @@ App.Editor = App.Editor || {}
 #
 # `extension` is a function because window.CM6 is populated by the module shim
 # in index.gsp and must not be dereferenced while this file is being evaluated.
+#
+# No CodeMirror 6 theme is published as a webjar beyond @codemirror/theme-one-dark,
+# so everything except one-dark is defined here.
 
-# https://ethanschoonover.com/solarized/ — no CodeMirror 6 port of this is
-# published as a webjar, so it is defined here rather than pulled in.
+# https://ethanschoonover.com/solarized/ — one palette, two themes: the accents
+# are shared and only the base tones swap, which is the whole point of it.
 SOLARIZED =
-  base03: '#002b36', base01: '#586e75', base00: '#657b83', base0: '#839496'
-  base1:  '#93a1a1', base2:  '#eee8d5', base3:  '#fdf6e3'
+  base03: '#002b36', base02: '#073642', base01: '#586e75', base00: '#657b83'
+  base0:  '#839496', base1:  '#93a1a1', base2:  '#eee8d5', base3:  '#fdf6e3'
   yellow: '#b58900', orange: '#cb4b16', red:    '#dc322f', magenta: '#d33682'
   violet: '#6c71c4', blue:   '#268bd2', cyan:   '#2aa198', green:   '#859900'
 
-solarizedLight = ->
-  {EditorView, HighlightStyle, syntaxHighlighting, tags} = window.CM6
+# https://draculatheme.com/contribute — official palette
+DRACULA =
+  background: '#282a36', currentLine: '#44475a', foreground: '#f8f8f2'
+  comment:    '#6272a4', cyan: '#8be9fd', green: '#50fa7b', orange: '#ffb86c'
+  pink:       '#ff79c6', purple: '#bd93f9', red: '#ff5555', yellow: '#f1fa8c'
 
-  theme = EditorView.theme
-    '&': {color: SOLARIZED.base00, backgroundColor: SOLARIZED.base3}
-    '.cm-content': {caretColor: SOLARIZED.base01}
-    '.cm-cursor, .cm-dropCursor': {borderLeftColor: SOLARIZED.base01}
+# Builds the EditorView.theme half from a small set of surface colours, so every
+# theme below only has to say what its surfaces are.
+buildTheme = (c, dark) ->
+  window.CM6.EditorView.theme
+    '&': {color: c.fg, backgroundColor: c.bg}
+    '.cm-content': {caretColor: c.caret}
+    '.cm-cursor, .cm-dropCursor': {borderLeftColor: c.caret}
     '&.cm-focused .cm-selectionBackgroundInactive, .cm-selectionBackground, ::selection':
-      {backgroundColor: SOLARIZED.base2}
-    '.cm-activeLine': {backgroundColor: '#eee8d580'}
-    '.cm-gutters':
-      {backgroundColor: SOLARIZED.base2, color: SOLARIZED.base1, border: 'none'}
-    '.cm-activeLineGutter': {backgroundColor: SOLARIZED.base2, color: SOLARIZED.base01}
+      {backgroundColor: c.selection}
+    '.cm-activeLine': {backgroundColor: c.activeLine}
+    '.cm-gutters': {backgroundColor: c.gutterBg, color: c.gutterFg, border: 'none'}
+    '.cm-activeLineGutter': {backgroundColor: c.gutterBg, color: c.fg}
     '.cm-matchingBracket, .cm-nonmatchingBracket':
-      {backgroundColor: SOLARIZED.base2, outline: "1px solid #{SOLARIZED.base1}"}
-  , dark: false
+      {backgroundColor: c.selection, outline: "1px solid #{c.gutterFg}"}
+  , dark: dark
 
-  highlight = HighlightStyle.define [
-    {tag: tags.keyword,                    color: SOLARIZED.green}
+# The tag-to-colour mapping is identical in shape for every theme; only the
+# colours differ, so it is written once.
+buildHighlight = (c) ->
+  {HighlightStyle, tags} = window.CM6
+  HighlightStyle.define [
+    {tag: tags.keyword,                                       color: c.keyword}
     {tag: [tags.name, tags.deleted, tags.character, tags.propertyName, tags.macroName],
-                                           color: SOLARIZED.base00}
-    {tag: [tags.function(tags.variableName), tags.labelName], color: SOLARIZED.blue}
+                                                              color: c.fg}
+    {tag: [tags.function(tags.variableName), tags.labelName], color: c.function}
     {tag: [tags.color, tags.constant(tags.name), tags.standard(tags.name)],
-                                           color: SOLARIZED.yellow}
-    {tag: [tags.definition(tags.name), tags.separator], color: SOLARIZED.base01}
+                                                              color: c.constant}
+    {tag: [tags.definition(tags.name), tags.separator],       color: c.definition}
     {tag: [tags.typeName, tags.className, tags.number, tags.changed,
            tags.annotation, tags.modifier, tags.self, tags.namespace],
-                                           color: SOLARIZED.violet}
+                                                              color: c.type}
     {tag: [tags.operator, tags.operatorKeyword, tags.url, tags.escape,
-           tags.regexp, tags.link, tags.special(tags.string)],
-                                           color: SOLARIZED.cyan}
-    {tag: [tags.meta, tags.comment],       color: SOLARIZED.base1, fontStyle: 'italic'}
+           tags.regexp, tags.link, tags.special(tags.string)], color: c.operator}
+    {tag: [tags.meta, tags.comment],       color: c.comment, fontStyle: 'italic'}
     {tag: tags.strong,                     fontWeight: 'bold'}
     {tag: tags.emphasis,                   fontStyle: 'italic'}
     {tag: tags.strikethrough,              textDecoration: 'line-through'}
     {tag: tags.link,                       textDecoration: 'underline'}
-    {tag: tags.heading,                    fontWeight: 'bold', color: SOLARIZED.orange}
-    {tag: [tags.atom, tags.bool, tags.special(tags.variableName)], color: SOLARIZED.magenta}
-    {tag: [tags.processingInstruction, tags.string, tags.inserted], color: SOLARIZED.cyan}
-    {tag: tags.invalid,                    color: SOLARIZED.red}
+    {tag: tags.heading,                    fontWeight: 'bold', color: c.heading}
+    {tag: [tags.atom, tags.bool, tags.special(tags.variableName)], color: c.atom}
+    {tag: [tags.processingInstruction, tags.string, tags.inserted], color: c.string}
+    {tag: tags.invalid,                    color: c.invalid}
   ]
 
-  [theme, syntaxHighlighting(highlight)]
+build = (colours, dark) -> ->
+  [buildTheme(colours, dark), window.CM6.syntaxHighlighting(buildHighlight colours)]
+
+solarized = (dark) ->
+  s = SOLARIZED
+  surfaces =
+    if dark
+      {bg: s.base03, fg: s.base0,  caret: s.base1,  selection: s.base02
+       activeLine: '#07364280', gutterBg: s.base02, gutterFg: s.base01
+       comment: s.base01, definition: s.base1}
+    else
+      {bg: s.base3,  fg: s.base00, caret: s.base01, selection: s.base2
+       activeLine: '#eee8d580', gutterBg: s.base2,  gutterFg: s.base1
+       comment: s.base1,  definition: s.base01}
+  build $.extend({}, surfaces,
+    keyword: s.green, function: s.blue, constant: s.yellow, type: s.violet
+    operator: s.cyan, heading: s.orange, atom: s.magenta, string: s.cyan
+    invalid: s.red), dark
+
+dracula = ->
+  d = DRACULA
+  build
+    bg: d.background, fg: d.foreground, caret: d.foreground
+    selection: d.currentLine, activeLine: '#44475a70'
+    gutterBg: d.background, gutterFg: d.comment
+    comment: d.comment, definition: d.green
+    keyword: d.pink, function: d.green, constant: d.purple, type: d.cyan
+    operator: d.pink, heading: d.purple, atom: d.purple, string: d.yellow
+    invalid: d.red
+  , true
 
 App.Editor.themes =
   'default':
     chrome: 'light'
     extension: -> []
+  'solarized-light':
+    chrome: 'light'
+    extension: -> solarized(false)()
   'one-dark':
     chrome: 'dark'
     extension: -> window.CM6.oneDark
-  'solarized-light':
-    chrome: 'light'
-    extension: solarizedLight
+  'solarized-dark':
+    chrome: 'dark'
+    extension: -> solarized(true)()
+  'dracula':
+    chrome: 'dark'
+    extension: -> dracula()()
 
 App.Editor.themeFor = (name) ->
   App.Editor.themes[name] ? App.Editor.themes['default']

--- a/web/templates/main/settings.hbs
+++ b/web/templates/main/settings.hbs
@@ -14,6 +14,8 @@
 <li><a href="#" class="dropdown-item setting theme" data-theme="default"><i class="bi bi-check-lg"></i> Light</a></li>
 <li><a href="#" class="dropdown-item setting theme" data-theme="one-dark"><i class="bi bi-check-lg"></i> Dark</a></li>
 <li><a href="#" class="dropdown-item setting theme" data-theme="solarized-light"><i class="bi bi-check-lg"></i> Solarized Light</a></li>
+<li><a href="#" class="dropdown-item setting theme" data-theme="solarized-dark"><i class="bi bi-check-lg"></i> Solarized Dark</a></li>
+<li><a href="#" class="dropdown-item setting theme" data-theme="dracula"><i class="bi bi-check-lg"></i> Dracula</a></li>
 <li><hr class="dropdown-divider"></li>
 <li><h6 class="dropdown-header">Editor</h6></li>
 <li><a href="#" class="dropdown-item setting auto-import-domains"><i class="bi bi-check-lg"></i> Auto import domain classes</a></li>


### PR DESCRIPTION
Two light themes and one dark was lopsided. This brings it to two and three: Light, Solarized Light, Dark (one-dark), Solarized Dark, Dracula.

**Solarized Dark costs no new colour values.** Solarized is one palette whose accents are shared and whose base tones simply swap, and the dark tones were already sitting unused in the constant — only `base02` had to be added. It also completes the pair with the Solarized Light already shipped.

**Dracula** is a genuinely new palette, taken from the project's published one. It's the most widely adopted dark theme across editors, which is why it was the pick for the "popular" slot.

### Restructuring rather than copying

`themes.coffee` is reorganised so the two themes don't arrive as near-identical 40-line blocks. The tag-to-colour mapping has the same shape for every theme, so `buildHighlight` states it once and each theme supplies colours; `buildTheme` does the same for the surfaces. Adding a theme is now a table of eight surface colours plus one line in `settings.hbs`, and the light and dark Solarized variants share a single definition instead of diverging.

No CodeMirror 6 theme is published as a webjar beyond `@codemirror/theme-one-dark`, so these are hand-written, as Solarized Light already was. They add no dependency and no request — roughly 5K in the bundle.

### Verification

Across all five themes in the bundled app: chrome tracks each one (light for `default` and `solarized-light`, dark for the rest), backgrounds land on their palettes exactly — `solarized-dark` on `#002b36` with `#073642` gutters, `dracula` on `#282a36` — the `darkTheme` facet is set correctly, and keywords, numerals, strings and comments each take their intended colour. 33 jasmine specs pass.